### PR TITLE
Waveform benchmarking

### DIFF
--- a/waveform_benchmark.py
+++ b/waveform_benchmark.py
@@ -1,0 +1,6 @@
+#!/usr/bin/env python3
+
+import waveform_benchmark.__main__
+
+if __name__ == '__main__':
+    waveform_benchmark.__main__.main()

--- a/waveform_benchmark/__main__.py
+++ b/waveform_benchmark/__main__.py
@@ -1,0 +1,17 @@
+import argparse
+
+from waveform_benchmark.benchmark import run_benchmarks
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('input_record')
+    ap.add_argument('format_class')
+    opts = ap.parse_args()
+
+    run_benchmarks(input_record=opts.input_record,
+                   format_class=opts.format_class)
+
+
+if __name__ == '__main__':
+    main()

--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -1,0 +1,122 @@
+#!/usr/bin/python3
+
+import importlib
+import os
+import random
+import tempfile
+import time
+
+from waveform_benchmark.input import load_wfdb_signals
+from waveform_benchmark.ioperf import PerformanceCounter
+from waveform_benchmark.utils import repeat_test
+from waveform_benchmark.utils import median_attr
+
+
+def run_benchmarks(input_record, format_class):
+    # Load the class we will be testing
+    module_name, class_name = format_class.rsplit('.', 1)
+    module = importlib.import_module(module_name)
+    fmt = getattr(module, class_name)
+
+    # Load the example data
+    input_record = input_record.removesuffix('.hea')
+    waveforms = load_wfdb_signals(input_record)
+    all_channels = list(waveforms.keys())
+
+    total_length = 0
+    timepoints_per_second = 0
+    actual_samples = 0
+    for waveform in waveforms.values():
+        channel_length = waveform['chunks'][-1]['end_time']
+        total_length = max(total_length, channel_length)
+        timepoints_per_second += waveform['samples_per_second']
+        actual_samples += sum(len(chunk['samples'])
+                              for chunk in waveform['chunks'])
+    total_timepoints = total_length * timepoints_per_second
+
+    TEST_BLOCK_LENGTHS = [
+        [total_length, 1],
+        [500, 5],               # 5 random blocks of 500 seconds
+        [50, 50],               # 50 random blocks of 50 seconds
+        [5, 500],               # 500 random blocks of 5 seconds
+    ]
+
+    TEST_MIN_DURATION = 10
+    TEST_MIN_ITERATIONS = 3
+
+    print('_' * 64)
+    print('Format: %s' % format_class)
+    if fmt.__doc__:
+        print('         (%s)'
+              % fmt.__doc__.strip().splitlines()[0].rstrip('.'))
+
+    print('Record: %s' % input_record)
+    print('         %.0f seconds x %d channels'
+          % (total_length, len(all_channels)))
+    print('         %d timepoints, %d samples (%.1f%%)'
+          % (total_timepoints, actual_samples,
+             100 * actual_samples / total_timepoints))
+    print('_' * 64)
+
+    with tempfile.TemporaryDirectory(prefix='wavetest-', dir='.') as tempdir:
+        path = os.path.join(tempdir, 'wavetest')
+
+        # Write the example data to a file or files.
+        with PerformanceCounter() as pc_write:
+            fmt().write_waveforms(path, waveforms)
+
+        # Calculate total size of the file(s).
+        output_size = 0
+        for subdir, dirs, files in os.walk(tempdir):
+            for file in files:
+                output_size += os.path.getsize(os.path.join(subdir, file))
+
+        print('Output size:    %.0f KiB (%.2f bits/sample)'
+              % (output_size / 1024, output_size * 8 / actual_samples))
+        print('Time to output: %.0f sec' % pc_write.cpu_seconds)
+        print('_' * 64)
+        print('Read performance (median of N trials):')
+        print(' #seek  #read      KiB      sec     [N]')
+
+        for block_length, block_count in TEST_BLOCK_LENGTHS:
+            counters = []
+            for i in repeat_test(TEST_MIN_DURATION, TEST_MIN_ITERATIONS):
+                r = random.Random(12345)
+                with PerformanceCounter() as pc:
+                    for j in range(block_count):
+                        t0 = r.random() * (total_length - block_length)
+                        t1 = t0 + block_length
+                        fmt().read_waveforms(path, t0, t1, all_channels)
+                counters.append(pc)
+
+            print('%6d %6d %8.0f %8.4f  %6s read %d x %.0fs, all channels'
+                  % (median_attr(counters, 'n_seek_calls'),
+                     median_attr(counters, 'n_read_calls'),
+                     median_attr(counters, 'n_bytes_read') / 1024,
+                     median_attr(counters, 'cpu_seconds'),
+                     '[%d]' % len(counters),
+                     block_count,
+                     block_length))
+
+        for block_length, block_count in TEST_BLOCK_LENGTHS:
+            counters = []
+            r = random.Random(12345)
+            for i in repeat_test(TEST_MIN_DURATION, TEST_MIN_ITERATIONS):
+                with PerformanceCounter() as pc:
+                    for j in range(block_count):
+                        t0 = r.random() * (total_length - block_length)
+                        t1 = t0 + block_length
+                        c = r.choice(all_channels)
+                        fmt().read_waveforms(path, t0, t1, [c])
+                counters.append(pc)
+
+            print('%6d %6d %8.0f %8.4f  %6s read %d x %.0fs, one channel'
+                  % (median_attr(counters, 'n_seek_calls'),
+                     median_attr(counters, 'n_read_calls'),
+                     median_attr(counters, 'n_bytes_read') / 1024,
+                     median_attr(counters, 'cpu_seconds'),
+                     '[%d]' % len(counters),
+                     block_count,
+                     block_length))
+
+    print('_' * 64)

--- a/waveform_benchmark/formats/base.py
+++ b/waveform_benchmark/formats/base.py
@@ -1,0 +1,26 @@
+import abc
+
+
+class BaseFormat(abc.ABC):
+    """
+    Abstract class for data formats to be tested.
+
+    For each data format that we want to benchmark, a class must be
+    defined that inherits from this class and defines the following
+    methods:
+
+    - write_waveforms: take a collection of waveform data, and save
+      the data to one or more files on disk
+
+    - read_waveforms: load waveforms from one or more files, and
+      return the requested subset of the data
+    """
+
+    @abc.abstractmethod
+    def write_waveforms(self, path: str, waveforms: dict):
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def read_waveforms(self, path: str, start_time: float, end_time: float,
+                       signal_names: list):
+        raise NotImplementedError

--- a/waveform_benchmark/formats/pickle.py
+++ b/waveform_benchmark/formats/pickle.py
@@ -1,0 +1,47 @@
+import pickle
+
+import numpy
+
+from waveform_benchmark.formats.base import BaseFormat
+
+
+class Pickle(BaseFormat):
+    """
+    Dummy example format using Pickle.
+    """
+
+    def write_waveforms(self, path, waveforms):
+        # Convert each channel into an array with no gaps.
+        flattened_waveforms = {}
+        for name, waveform in waveforms.items():
+            length = waveform['chunks'][-1]['end_sample']
+            samples = numpy.empty(length, dtype=numpy.float32)
+            samples[:] = numpy.nan
+            for chunk in waveform['chunks']:
+                start = chunk['start_sample']
+                end = chunk['end_sample']
+                samples[start:end] = chunk['samples']
+
+            flattened_waveforms[name] = {
+                'units': waveform['units'],
+                'samples_per_second': waveform['samples_per_second'],
+                'samples': samples,
+            }
+
+        # Dump flattened waveforms to a file.
+        with open(path, 'wb') as f:
+            pickle.dump(flattened_waveforms, f)
+
+    def read_waveforms(self, path, start_time, end_time, signal_names):
+        # Read arrays into memory.
+        with open(path, 'rb') as f:
+            channels = pickle.load(f)
+
+        # Extract the requested samples from the array.
+        results = {}
+        for signal_name in signal_names:
+            channel = channels[signal_name]
+            start_sample = round(start_time / channel['samples_per_second'])
+            end_sample = round(end_time / channel['samples_per_second'])
+            results[signal_name] = channel['samples'][start_sample:end_sample]
+        return results

--- a/waveform_benchmark/formats/wfdb.py
+++ b/waveform_benchmark/formats/wfdb.py
@@ -1,0 +1,104 @@
+import os
+
+import numpy
+import wfdb
+
+from waveform_benchmark.formats.base import BaseFormat
+
+
+class BaseWFDBFormat(BaseFormat):
+    """
+    Abstract class for WFDB signal formats.
+    """
+
+    # Currently, this class uses a single segment and stores many
+    # signals in one signal file.  Using multiple segments and
+    # multiple signal files could improve efficiency of storage and
+    # per-channel access.
+
+    def write_waveforms(self, path, waveforms):
+        sig_name = []
+        units = []
+        sfreq = []
+        adc_gain = []
+        baseline = []
+        e_p_signal = []
+
+        length = max(waveform['chunks'][-1]['end_time']
+                     for waveform in waveforms.values())
+
+        for name, waveform in waveforms.items():
+            sig_name.append(name)
+            units.append(waveform['units'])
+            sfreq.append(waveform['samples_per_second'])
+
+            # Convert chunks into an array with no gaps.
+            sig_length = round(length * waveform['samples_per_second'])
+            sig_samples = numpy.empty(sig_length, dtype=numpy.float32)
+            sig_samples[:] = numpy.nan
+            sig_gain = 0
+            for chunk in waveform['chunks']:
+                start = chunk['start_sample']
+                end = chunk['end_sample']
+                sig_samples[start:end] = chunk['samples']
+                sig_gain = max(sig_gain, chunk['gain'])
+
+            sample_min = numpy.nanmin(sig_samples)
+            sample_max = numpy.nanmax(sig_samples)
+            sig_baseline = round(-sig_gain * (sample_min + sample_max) / 2)
+            adc_gain.append(sig_gain)
+            baseline.append(sig_baseline)
+            e_p_signal.append(sig_samples)
+
+        # Calculate frame frequency as GCD of sampling frequencies.
+        ffreqs = sorted(set(sfreq))
+        while len(ffreqs) > 1 and ffreqs[-1] < ffreqs[-2] * 10000:
+            ffreqs[-1] %= ffreqs[-2]
+            ffreqs.sort()
+        fs = ffreqs[-1]
+        samps_per_frame = [round(f / fs) for f in sfreq]
+
+        # Write out data as a WFDB record.
+        rec = wfdb.Record(
+            record_name=os.path.basename(path),
+            n_sig=len(sig_name),
+            fmt=[self.fmt] * len(sig_name),
+            fs=fs,
+            samps_per_frame=samps_per_frame,
+            sig_name=sig_name,
+            units=units,
+            adc_gain=adc_gain,
+            baseline=baseline,
+            e_p_signal=e_p_signal,
+        )
+        rec.e_d_signal = rec.adc(expanded=True)
+        rec.set_d_features(expanded=True)
+        rec.set_defaults()
+        rec.wrsamp(write_dir=os.path.dirname(path), expanded=True)
+
+    def read_waveforms(self, path, start_time, end_time, signal_names):
+        header = wfdb.rdheader(path)
+        start_frame = round(start_time * header.fs)
+        end_frame = round(end_time * header.fs)
+
+        record = wfdb.rdrecord(path, sampfrom=start_frame, sampto=end_frame,
+                               channel_names=signal_names, smooth_frames=False,
+                               return_res=32)
+        results = {}
+        for signal_name, samples in zip(record.sig_name, record.e_p_signal):
+            results[signal_name] = samples
+        return results
+
+
+class WFDBFormat16(BaseWFDBFormat):
+    """
+    WFDB with 16-bit binary storage.
+    """
+    fmt = '16'
+
+
+class WFDBFormat516(BaseWFDBFormat):
+    """
+    WFDB with FLAC compression.
+    """
+    fmt = '516'

--- a/waveform_benchmark/input.py
+++ b/waveform_benchmark/input.py
@@ -1,0 +1,63 @@
+import numpy
+import wfdb
+
+
+def load_wfdb_signals(record_name, pn_dir=None, start=None, end=None):
+    header = wfdb.rdheader(record_name, pn_dir=pn_dir)
+    if start is None:
+        start = 0
+    start = round(header.get_frame_number(start))
+    if end is None:
+        end = header.sig_len
+    end = round(header.get_frame_number(end))
+
+    record = wfdb.rdrecord(record_name, pn_dir=pn_dir, return_res=32,
+                           smooth_frames=False, m2s=False,
+                           sampfrom=start, sampto=end)
+
+    if isinstance(record, wfdb.MultiRecord):
+        segments = record.segments
+        segment_lengths = record.seg_len
+    else:
+        segments = [record]
+        segment_lengths = [record.sig_len]
+    layout = segments[0]
+
+    waveforms = {}
+
+    for i, name in enumerate(layout.sig_name):
+        waveform = {
+            'units': layout.units[i],
+            'samples_per_second': layout.fs * layout.samps_per_frame[i],
+            'chunks': [],
+        }
+        waveforms[name] = waveform
+
+    end_frame = 0
+    for seg, seg_len in zip(segments, segment_lengths):
+        start_frame = end_frame
+        end_frame += seg_len
+        if seg is None or seg_len == 0:
+            continue
+        for i, name in enumerate(seg.sig_name):
+            chunk = {
+                'start_time': start_frame / layout.fs,
+                'end_time': end_frame / layout.fs,
+                'start_sample': start_frame * layout.samps_per_frame[i],
+                'end_sample': end_frame * layout.samps_per_frame[i],
+                'gain': seg.adc_gain[i],
+                'samples': seg.e_p_signal[i],
+            }
+            wave_chunks = waveforms[name]['chunks']
+            if (wave_chunks
+                    and wave_chunks[-1]['end_sample'] == chunk['start_sample']
+                    and wave_chunks[-1]['gain'] == chunk['gain']):
+                wave_chunks[-1]['end_sample'] = chunk['end_sample']
+                wave_chunks[-1]['end_time'] = chunk['end_time']
+                wave_chunks[-1]['samples'] = numpy.concatenate(
+                    (wave_chunks[-1]['samples'], chunk['samples'])
+                )
+            else:
+                wave_chunks.append(chunk)
+
+    return waveforms

--- a/waveform_benchmark/ioperf.py
+++ b/waveform_benchmark/ioperf.py
@@ -1,0 +1,124 @@
+import os
+import re
+import resource
+import signal
+import subprocess
+import sys
+import threading
+
+
+class PerformanceCounter:
+    """
+    Context manager to measure CPU and I/O usage.
+
+    This object has the following attributes, which (approximately)
+    represent the system resources that are used during execution of
+    the context manager - that is to say, anything that happens before
+    or after the "with" block doesn't count.
+
+      'n_read_calls': Number of times the read() system call was
+                      invoked.
+
+      'n_seek_calls': Number of times the lseek() system call was
+                      invoked.
+
+      'n_bytes_read': Number of bytes that were read from disk.
+
+      'cpu_seconds':  Number of seconds that the CPU was busy
+                      (multiplied by the number of CPU cores in use.)
+
+    If the 'clear_cache' argument is true, then attempt to clear the
+    system cache whenever a file is opened (so that 'n_bytes_read'
+    should reflect the total number of bytes retrieved.)  Note that
+    'clear_cache' *only* affects files that are opened through Python
+    (using the open() or os.open() functions) and depends on the
+    filesystem (it won't work on tmpfs, for instance.)
+    """
+    def __init__(self, clear_cache=True):
+        self._clear_cache = clear_cache
+        self.n_read_calls = 0
+        self.n_seek_calls = 0
+        self.n_bytes_read = 0
+        self.cpu_seconds = 0
+
+    def __enter__(self):
+        if self._clear_cache:
+            with _nocache_lock:
+                _nocache_enabled.add(self)
+
+        # Run strace to track system calls.
+        self._strace = subprocess.Popen(['strace', '-c', '-f',
+                                         '-U', 'name,calls',
+                                         '-e', 'lseek,read',
+                                         '-p', str(os.getpid())],
+                                        stdout=subprocess.PIPE,
+                                        stderr=subprocess.STDOUT)
+        # Wait for strace to attach to the current process.  (Subtract
+        # one from n_read_calls because this counts as one.)
+        self._strace.stdout.readline()
+        self.n_read_calls -= 1
+
+        # Measure past resource usage for this process and any children.
+        self._rusage_self = resource.getrusage(resource.RUSAGE_SELF)
+        self._rusage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        # Measure current resource usage for this process and any children.
+        rusage_self = resource.getrusage(resource.RUSAGE_SELF)
+        rusage_children = resource.getrusage(resource.RUSAGE_CHILDREN)
+
+        with _nocache_lock:
+            _nocache_enabled.discard(self)
+
+        # Stop the strace process and read its output.
+        self._strace.send_signal(signal.SIGINT)
+        strace_data, _ = self._strace.communicate()
+        for m in re.finditer(rb'^\s*(\w+)\s+(\d+)\s*$',
+                             strace_data, re.MULTILINE):
+            if m.group(1) == b'read':
+                self.n_read_calls += int(m.group(2))
+            elif m.group(1) == b'lseek':
+                self.n_seek_calls += int(m.group(2))
+
+        # Calculate number of bytes read.  ru_inblock is always
+        # measured in 512-byte blocks regardless of I/O block size.
+        self.n_bytes_read += 512 * (rusage_self.ru_inblock
+                                    + rusage_children.ru_inblock
+                                    - self._rusage_self.ru_inblock
+                                    - self._rusage_children.ru_inblock)
+
+        # Calculate CPU seconds, including both user and kernel time.
+        self.cpu_seconds += (rusage_self.ru_utime
+                             + rusage_self.ru_stime
+                             + rusage_children.ru_utime
+                             + rusage_children.ru_stime
+                             - self._rusage_self.ru_utime
+                             - self._rusage_self.ru_stime
+                             - self._rusage_children.ru_utime
+                             - self._rusage_children.ru_stime)
+
+
+def _nocache_hook(event, args):
+    global _nocache_loop
+    if event == 'open' and not _nocache_loop:
+        with _nocache_lock:
+            if _nocache_enabled and isinstance(args[0], (str, bytes)):
+                _nocache_loop = True
+                fd = None
+                try:
+                    fd = os.open(args[0], os.O_RDONLY | os.O_CLOEXEC)
+                    os.posix_fadvise(fd, 0, 0, os.POSIX_FADV_DONTNEED)
+                except OSError:
+                    pass
+                finally:
+                    if fd is not None:
+                        os.close(fd)
+                    _nocache_loop = False
+
+
+_nocache_lock = threading.Lock()
+_nocache_enabled = set()
+_nocache_loop = False
+sys.addaudithook(_nocache_hook)

--- a/waveform_benchmark/utils.py
+++ b/waveform_benchmark/utils.py
@@ -1,0 +1,18 @@
+import time
+
+
+def repeat_test(min_duration, min_iterations):
+    end = time.time() + min_duration
+    for _ in range(min_iterations):
+        yield
+    while time.time() < end:
+        yield
+
+
+def median_attr(objects, attr):
+    values = []
+    for obj in objects:
+        values.append(getattr(obj, attr))
+    values.sort()
+    n = len(values)
+    return (values[n // 2] + values[(n - 1) // 2]) / 2


### PR DESCRIPTION
This pull adds a set of Python scripts for testing and benchmarking waveform storage formats.

For any waveform format, we want to have a Python API for reading and writing that format.  The objective here is to benchmark that API's performance as well as the storage efficiency of the format itself.

(Of course, the Python API needn't be the only API, and in fact the Python API should probably be implemented in some more performant language - wfdb-python, for example, is based on numpy which is implemented in C.)

So for each format, we'll want to define a Python class with two methods:
- one method to write waveform data from memory to disk
- one method to read waveform data from disk into memory

(More features and methods may be added later.)

The `run_benchmarks` function will then use these two methods to run a bunch of tests and report their performance.

Here's an example, to give you an idea of what this outputs:
```
________________________________________________________________
Format: waveform_benchmark.formats.wfdb.WFDBFormat516
         (WFDB with FLAC compression)
Record: data/s00001-2896-10-10-00-31
         116147 seconds x 4 channels
         58073460 timepoints, 28425000 samples (48.9%)
________________________________________________________________
Output size:    11775 KiB (3.39 bits/sample)
Time to output: 18 sec
________________________________________________________________
Read performance (median of N trials):
 #seek  #read      KiB      sec     [N]
  1780   1563    11784   1.0967     [9] read 1 x 116147s, all channels
   300    136     1904   0.0636   [111] read 5 x 500s, all channels
  2371    908     8880   0.3640    [19] read 50 x 50s, all channels
 25298   9315    70216   3.4233     [3] read 500 x 5s, all channels
  1780   1563    11784   0.8176    [12] read 1 x 116147s, one channel
   260    115     1556   0.0532   [123] read 5 x 500s, one channel
  2478    934     9432   0.3775    [19] read 50 x 50s, one channel
 27080   9915    70004   3.5648     [3] read 500 x 5s, one channel
________________________________________________________________
```

This framework is still a work in progress:
- It should test that the read method actually returns the same data as what was passed to the write method.
- The benchmarks themselves should be more detailed and more thorough (and take longer to run.)
- Make it work on non-Linux systems.  (I have zero interest in implementing performance metrics on non-Linux, but it'd be nice to be able to test the formats themselves on other systems.)
- The API could be improved, and needs to be documented!

