### PR TITLE
Add option to loop through multiple waveforms when running benchmarking

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -4,18 +4,18 @@
 
 The benchmarking script includes a simple set of metrics to evaluate the performance of waveform formats in Python. The benchmarks are intended to be run from the command line on Linux-systems only.
 
-## Running a benchmark
+## Running a benchmark on a single file
 
 The [waveform_benchmark.py](./waveform_benchmark.py) script is the entrypoint for running benchmarks. This script calls functions in the `waveform_benchmark` package. The syntax for running waveform_benchmark.py from the command line is: 
 
 ```
-./waveform_benchmark.py <PATH_TO_RECORD> <PATH_TO_BENCHMARK_CLASS>
+./waveform_benchmark.py -r <PATH_TO_RECORD> -f <PATH_TO_BENCHMARK_CLASS> -p <PHYSIONET_DATABASE_PATH>
 ```
 
-For example, to run the `WFDBFormat516` benchmark on a record named `data/waveforms/mimic_iv/waves/p100/p10079700/85594648/85594648`:
+The `-p` argument can be used to pull a file directly from a PhysioNet database but isn't needed when running on a local file. For example, to run the `WFDBFormat516` benchmark on local record `data/waveforms/mimic_iv/waves/p100/p10079700/85594648/85594648`:
 
 ```
-./waveform_benchmark.py ./data/waveforms/mimic_iv/waves/p100/p10079700/85594648/85594648 waveform_benchmark.formats.wfdb.WFDBFormat516
+./waveform_benchmark.py -r ./data/waveforms/mimic_iv/waves/p100/p10079700/85594648/85594648 -f waveform_benchmark.formats.wfdb.WFDBFormat516
 ```
 
 An example output is provided below:
@@ -41,6 +41,35 @@ Read performance (median of N trials):
    240    123     1668   0.0714   [110] read 5 x 500s, one channel
   1902    738     7616   0.2974    [24] read 50 x 50s, one channel
  18932   7061    53596   2.5504     [3] read 500 x 5s, one channel
+```
+
+Similarly, this file can be pulled directly from the MIMIC-IV Waveform PhysioNet database by running this:
+
+```
+./waveform_benchmark.py -r 85594648 -f waveform_benchmark.formats.wfdb.WFDBFormat516 -p mimic4wdb/0.1.0/waves/p100/p10079700/85594648/
+```
+
+## Running benchmarking on multiple files and formats
+
+To run benchmarking on multiple files and/or formats you need to pass a CSV control file by using the `-s` argument. The control file needs to start with a header like:
+
+`record,format,pn_dir`
+
+and be followed by rows which specify `record` and `format`. Adding a `<PHYSIONET_DATABASE_PATH>`, in the `pn_dir` column, is optional and will pull files directly from PhysioNet if provided. Here is an example of a CSV control file:
+
+```
+record,format,pn_dir
+charis1.hea,waveform_benchmark.formats.wfdb.WFDBFormat16,charisdb/1.0.0/
+charis1.hea,waveform_benchmark.formats.wfdb.WFDBFormat516,charisdb/1.0.0/
+84050536.hea,waveform_benchmark.formats.wfdb.WFDBFormat16,mimic4wdb/0.1.0/waves/p100/p10082591/84050536/
+85594648.hea,waveform_benchmark.formats.wfdb.WFDBFormat16,mimic4wdb/0.1.0/waves/p100/p10079700/85594648/
+```
+
+This pulls all files for this benchmarking run directly from PhysioNet databases. The first file `charis1` is run against the uncompressed and compressed WFDB formats (`WFDBFormat16` and `WFDBFormat516` respectively). The last two lines run two different files from the MIMIC-IV Waveform database against the uncompressed WFDB format.
+
+If our CSV file is `benchmark_files.csv`, we can run it with this command:
+```
+./waveform_benchmark.py -s benchmark_files.csv
 ```
 
 ## Adding a new format to the benchmarks

--- a/waveform_benchmark/__main__.py
+++ b/waveform_benchmark/__main__.py
@@ -39,12 +39,13 @@ def main():
         waveform_suite = read_csv(opts.waveform_suite_table)
 
         for waveform_file in waveform_suite:
-            pn_dir = waveform_file[0]
-            record = waveform_file[1]
-            format = waveform_file[2]
+            record = waveform_file[0]
+            format = waveform_file[1]
+            pn_dir = waveform_file[2]
             run_benchmarks(input_record=record,
-                           pn_dir=pn_dir,
-                           format_class=format)
+                           format_class=format,
+                           pn_dir=pn_dir
+                           )
 
     # Run benchmarking against a single file
     else:

--- a/waveform_benchmark/__main__.py
+++ b/waveform_benchmark/__main__.py
@@ -1,16 +1,56 @@
 import argparse
+import csv
 
 from waveform_benchmark.benchmark import run_benchmarks
 
 
+def read_csv(file_path):
+    data = []
+    with open(file_path, 'r', newline='') as csvfile:
+        csv_reader = csv.reader(csvfile)
+        next(csv_reader)
+        for row in csv_reader:
+            data.append(row)
+    return data
+
+
 def main():
     ap = argparse.ArgumentParser()
-    ap.add_argument('input_record')
-    ap.add_argument('format_class')
+    ap.add_argument('--input_record', '-r',
+                    help='The record name to run benchmarking against')
+    ap.add_argument('--format_class', '-f',
+                    help='The format to save the waveform in')
+    ap.add_argument('--physionet_directory', '-p',
+                    default=None,
+                    help='The physionet database directory to read the source waveform from')
+    ap.add_argument('--waveform_suite_table', '-s',
+                    default=None,
+                    help='A csv table with input_record, physionet directory, and format class for multiple files')
     opts = ap.parse_args()
 
-    run_benchmarks(input_record=opts.input_record,
-                   format_class=opts.format_class)
+    # Check conditions based on the parsed arguments
+    if not opts.waveform_suite_table:
+        # If a waveform suite table is not provided, input_record and format_class must be provided
+        if opts.input_record is None or opts.format_class is None:
+            ap.error('--input_record and --format_class are required unless --waveform_suite_table is specified')
+
+    # If a table with multiple files is passed we loop through it
+    if opts.waveform_suite_table:
+        waveform_suite = read_csv(opts.waveform_suite_table)
+
+        for waveform_file in waveform_suite:
+            pn_dir = waveform_file[0]
+            record = waveform_file[1]
+            format = waveform_file[2]
+            run_benchmarks(input_record=record,
+                           pn_dir=pn_dir,
+                           format_class=format)
+
+    # Run benchmarking against a single file
+    else:
+        run_benchmarks(input_record=opts.input_record,
+                       format_class=opts.format_class,
+                       pn_dir=opts.physionet_directory)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This update gives the option to run the benchmarking code ( #12 ) on multiple waveforms. It also updates the input arguments to set the help option and indicate which arguments are required when running against a single waveform versus running against multiple waveforms. An upcoming PR will print out the filename being run. 