### PR TITLE
Add a summary of the signals for files being used for benchmarking

### DIFF
--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -27,13 +27,32 @@ def run_benchmarks(input_record, format_class, pn_dir=None):
     total_length = 0
     timepoints_per_second = 0
     actual_samples = 0
-    for waveform in waveforms.values():
+    waveform_characterizations = {}
+    for i, (name, waveform) in enumerate(waveforms.items()):
+        precise_channel_length = 0
         channel_length = waveform['chunks'][-1]['end_time']
         total_length = max(total_length, channel_length)
         timepoints_per_second += waveform['samples_per_second']
         actual_samples += sum(len(chunk['samples'])
                               for chunk in waveform['chunks'])
+
+        # Collect summary information about each channel in the waveform
+        inv_gain = 1/waveform['chunks'][-1]['gain']
+        res_rounded = f'{float(f"{inv_gain:.3g}"):g}'
+        resolution = f"{res_rounded}({waveforms[name]['units']})"
+        precise_channel_length += sum(chunk['end_time'] - chunk['start_time']
+                              for chunk in waveform['chunks'])
+        waveform_characterizations[name] = {
+        'fs': waveform['samples_per_second'],
+        'bit_resolution': resolution,
+        'channel_length': precise_channel_length
+        }
+
     total_timepoints = total_length * timepoints_per_second
+    if pn_dir:
+        record_name = os.path.join(pn_dir, input_record)
+    else:
+        record_name = input_record
 
     TEST_BLOCK_LENGTHS = [
         [total_length, 1],
@@ -51,12 +70,22 @@ def run_benchmarks(input_record, format_class, pn_dir=None):
         print('         (%s)'
               % fmt.__doc__.strip().splitlines()[0].rstrip('.'))
 
-    print('Record: %s' % input_record)
+    print('Record: %s' % record_name)
     print('         %.0f seconds x %d channels'
           % (total_length, len(all_channels)))
     print('         %d timepoints, %d samples (%.1f%%)'
           % (total_timepoints, actual_samples,
              100 * actual_samples / total_timepoints))
+    print('_' * 64)
+
+    # Print summary information for each waveform channel
+    print('Channel summary information:')
+    print(f" {'signal':<12} {'fs(Hz)':<10} {'Bit resolution':<20} {'Channel length(s)':<20}")
+    for (signal, values) in waveform_characterizations.items():
+        fs_value = f"{values['fs']:.2f}"
+        bit_resolution_value = values['bit_resolution']
+        channel_length_value = f"{values['channel_length']:.0f}"
+        print(f" {signal:<12} {fs_value:<10} {bit_resolution_value:<20} {channel_length_value:<20}")
     print('_' * 64)
 
     with tempfile.TemporaryDirectory(prefix='wavetest-', dir='.') as tempdir:


### PR DESCRIPTION
This adds an additional table to the benchmarking run (from #12) which prints out the signal name, fs (sample rate), bit resolution, and length for each signal. 