### PR TITLE
Minor changes to the benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -71,15 +71,9 @@ jobs:
       - name: Post results to pull request
         if: steps.find-formats.outputs.format_files != ''
         run: |
-          RESULTS=""
-          IFS=' ' read -ra FILES <<< "${{ steps.find-formats.outputs.format_files }}"
-          for file in "${FILES[@]}"
-          do
-            FORMAT_CLASS=$(echo "$file" | grep -oP 'formats/\K(.*)(?=\.py)')
-            echo "Processing file: $file"
-            RESULTS+="$FORMAT_CLASS:\n$(cat "benchmark_results_$FORMAT_CLASS.txt")\n"
-          done
-          echo -e "Benchmark results:\n\`\`\`\n$RESULTS\n\`\`\`" > final_results.txt
+          cat benchmark_results_*.txt > final_results.txt
+          echo "Benchmark results:"
+          cat final_results.txt
 
     #   - uses: unsplash/comment-on-pr@master
     #     if: steps.find-formats.outputs.format_files != ''

--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -34,13 +34,15 @@ jobs:
         run: |
           git fetch origin main
           FILES=$(git diff --diff-filter=AM --name-only origin/main...HEAD 'waveform_benchmark/formats/*.py')
-          echo "Format files: $FILES"
-          echo "::set-output name=format_files::$FILES"
-
+          echo "Format files: $FILES" > format_files.txt
+          cat format_files.txt
+          
       - name: Run benchmark tests on new or modified format files
         if: steps.find-formats.outputs.format_files != ''
         run: |
-          IFS=' ' read -ra FILES <<< "${{ steps.find-formats.outputs.format_files }}"
+          FORMAT_FILES=$(cat format_files.txt)
+          IFS=' ' read -ra FILES <<< "$FORMAT_FILES"
+          RECORD_NAME="./data/waveforms/mimic_iv/waves/p169/p16955095/82284982/82284982"
           for file in "${FILES[@]}"
           do
             # Skip base.py file
@@ -60,8 +62,9 @@ jobs:
             for cls in "${CLS[@]}"
             do
               CLASS_PATH="$MODULE_PATH.$cls"
+              FILENAME="benchmark_results_${cls}.txt"
               echo "Benchmarking $CLASS_PATH"
-              ./waveform_benchmark.py -r ./data/waveforms/mimic_iv/waves/p100/p10079700/85594648/85594648 -f "$CLASS_PATH" > "benchmark_results_${cls}.txt"
+              ./waveform_benchmark.py -r "$RECORD_NAME" -f "$CLASS_PATH" > "$FILENAME"
             done
           done
 
@@ -73,6 +76,7 @@ jobs:
           for file in "${FILES[@]}"
           do
             FORMAT_CLASS=$(echo "$file" | grep -oP 'formats/\K(.*)(?=\.py)')
+            echo "Processing file: $file"
             RESULTS+="$FORMAT_CLASS:\n$(cat "benchmark_results_$FORMAT_CLASS.txt")\n"
           done
           echo -e "Benchmark results:\n\`\`\`\n$RESULTS\n\`\`\`" > final_results.txt


### PR DESCRIPTION
This introduces a few minor changes to the benchmark workflow:

1. Switches to a smaller record, as discussed in https://github.com/chorus-ai/chorus_waveform/pull/42#issuecomment-2093240641
2. Simplifies the final step in the workflow that reports the results
3. Replaces deprecated `set-output` syntax:

```
Format files: waveform_benchmark/formats/parquet.py
Warning: The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
```