### PR TITLE
Skip benchmark classes beginning with `Base` in the benchmark workflow

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -59,7 +59,7 @@ jobs:
 
             # Find and list all classes in the module
             echo "Running benchmarks for classes in $MODULE_PATH"
-            CLASSES=$(python3 -c "import sys; import inspect; from importlib import import_module; mod = import_module('$MODULE_PATH'); print(' '.join(cls for cls, obj in inspect.getmembers(mod, inspect.isclass) if obj.__module__ == mod.__name__))")
+            CLASSES=$(python3 -c "import sys; import inspect; from importlib import import_module; mod = import_module('$MODULE_PATH'); print(' '.join(cls for cls, obj in inspect.getmembers(mod, inspect.isclass) if obj.__module__ == mod.__name__ and not cls.startswith('Base')))")
             IFS=' ' read -ra CLS <<< "$CLASSES"
 
             for cls in "${CLS[@]}"

--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -94,7 +94,9 @@ The module should be created at `./chorus_waveform/waveform_benchmark/formats/` 
 
 #### 3. Add a subclass of the [`BaseFormat`](./waveform_benchmark/formats/base.py).
 
-The class should be named `YourFormat(BaseFormat)` (e.g. `WFDBFormat(BaseFormat)`).
+The class should be named `YourFormat(BaseFormat)` (e.g. `WFDBFormat(BaseFormat)`). 
+
+If you are defining additional base classes that are not intended to be benchmarked directly, you should include `Base` at the start of the name (for example, "`BaseWFDBFormat`"). This allows us to slip the class in the [benchmark workflow](https://github.com/chorus-ai/chorus_waveform/blob/main/.github/workflows/benchmark.yml).
 
 #### 4. Add a `write_waveforms()` method.
 


### PR DESCRIPTION
At the moment the new benchmark workflow attempts to run all classes defined in the module. This results in an error for modules that include classes that are not intended to be benchmarked directly.

For example, the [WFDB module](https://github.com/chorus-ai/chorus_waveform/blob/main/waveform_benchmark/formats/wfdb.py) includes a `BaseWFDBFormat` that is not run directly. 

Instead `BaseWFDBFormat` is intended to be used through its two child classes: `WFDBFormat16` and `WFDBFormat516`