### PR TITLE
Tidying DICOM format for the purpose of testing #42

### DIFF
--- a/waveform_benchmark/formats/dicom.py
+++ b/waveform_benchmark/formats/dicom.py
@@ -641,7 +641,7 @@ class DICOMFormat8(BaseDICOMFormat):
     MemoryDataType = np.float32
 
 
-class DICOMFormat8(BaseDICOMFormat):
+class DICOMFormat8_v2(BaseDICOMFormat):
     WaveformSampleInterpretation = 'SB'
     WaveformBitsAllocated = 8
     # respiratory, gneral audio, realtime audio, ambulatory ECG, arterial pulse


### PR DESCRIPTION
Some tidying to the DICOM benchmark format, mainly to test https://github.com/chorus-ai/chorus_waveform/pull/42 (and perhaps to highlight any issues with this format, such as missing requirements).

@tcpan If you're still working on this format, please could you pull down the latest version from this repository to avoid conflicts. If it is difficult to resolve conflicts, it's not a problem if we overwrite the changes that I'm making here.