### PR TITLE
Summarize benchmarking runs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,8 @@ h5py==3.10.0
 numpy==1.26.4
 pyarrow==16.0.0
 pydicom==2.4.4
+tqdm==4.66.4
 vitaldb==1.4.8
 wfdb==4.1.2
 zarr==2.17.2
+

--- a/waveform_benchmark/__main__.py
+++ b/waveform_benchmark/__main__.py
@@ -4,6 +4,7 @@ import os
 import sys
 
 import pandas as pd
+from tqdm import tqdm
 
 from waveform_benchmark.benchmark import run_benchmarks
 
@@ -102,7 +103,7 @@ def main():
 
         format_list, waveform_list, test_list, result_list = init_summary_file(opts.waveform_suite_summary_file)
 
-        for waveform_file in waveform_suite:
+        for waveform_file in tqdm(waveform_suite):
             record = waveform_file[0]
             format = waveform_file[1]
             pn_dir = waveform_file[2]

--- a/waveform_benchmark/__main__.py
+++ b/waveform_benchmark/__main__.py
@@ -72,6 +72,9 @@ def main():
     ap.add_argument('--physionet_directory', '-p',
                     default=None,
                     help='The physionet database directory to read the source waveform from')
+    ap.add_argument('--save_output_to_log', '-l',
+                    default=False,
+                    help='Save all of the benchmarking results to a log file')
     ap.add_argument('--waveform_suite_table', '-s',
                     default=None,
                     help='A csv table with input_record, physionet directory, and format class for multiple files')
@@ -79,6 +82,13 @@ def main():
                     default=None,
                     help='Save a CSV summary of the waveform suite run to this path/file')
     opts = ap.parse_args()
+
+    # If log is requested send the output there
+    if opts.save_output_to_log:
+        log_file = open('benchmark_results.log', 'a')
+
+        # Send the output to the log file
+        sys.stdout = log_file
 
     # Check conditions based on the parsed arguments
     if not opts.waveform_suite_table:
@@ -96,7 +106,6 @@ def main():
             record = waveform_file[0]
             format = waveform_file[1]
             pn_dir = waveform_file[2]
-            # summary_file = opts.waveform_suite_summary_file
             format_list, waveform_list, test_list, result_list = run_benchmarks(input_record=record,
                                                                                 format_class=format, pn_dir=pn_dir,
                                                                                 format_list=format_list,
@@ -111,6 +120,10 @@ def main():
         run_benchmarks(input_record=opts.input_record,
                        format_class=opts.format_class,
                        pn_dir=opts.physionet_directory)
+
+    # Close the log file after the run is complete
+    if opts.save_output_to_log:
+        log_file.close()
 
 
 if __name__ == '__main__':

--- a/waveform_benchmark/__main__.py
+++ b/waveform_benchmark/__main__.py
@@ -79,7 +79,7 @@ def main():
                     default=None,
                     help='A csv table with input_record, physionet directory, and format class for multiple files')
     ap.add_argument('--waveform_suite_summary_file', '-w',
-                    default=None,
+                    default='waveform_suite_benchmark_summary.csv',
                     help='Save a CSV summary of the waveform suite run to this path/file')
     opts = ap.parse_args()
 

--- a/waveform_benchmark/__main__.py
+++ b/waveform_benchmark/__main__.py
@@ -1,17 +1,66 @@
 import argparse
 import csv
+import os
+import sys
+
+import pandas as pd
 
 from waveform_benchmark.benchmark import run_benchmarks
 
 
 def read_csv(file_path):
+    """
+    Read in a csv file with a header
+    """
     data = []
     with open(file_path, 'r', newline='') as csvfile:
         csv_reader = csv.reader(csvfile)
         next(csv_reader)
         for row in csv_reader:
             data.append(row)
+
     return data
+
+
+def init_summary_file(summary_file):
+    """
+    Initialize the summary lists - either grab existing data from a file to be appended to or create empty lists for all
+    new data
+    """
+    if os.path.exists(summary_file):
+        df_summary = pd.read_csv(summary_file)
+        try:
+            format_list = list(df_summary['format'])
+            waveform_list = list(df_summary['waveform'])
+            test_list = list(df_summary['test'])
+            result_list = list(df_summary['result'])
+        except:
+            print("Required columns not found in the waveform suite summary file")
+            sys.exit(1)
+    else:
+        format_list = []
+        waveform_list = []
+        test_list = []
+        result_list = []
+
+    return format_list, waveform_list, test_list, result_list
+
+
+def save_summary(format_list, waveform_list, test_list, result_list, summary_file):
+    """
+    Save a summary of the results to a CSV file
+    """
+    df_updated_summary = pd.DataFrame(zip(format_list, waveform_list, test_list, result_list),
+                                      columns=['format', 'waveform', 'test', 'result'])
+
+    # Add columns for the last identifier for format and waveform
+    df_updated_summary['format_id'] = df_updated_summary['format'].str.split('.').str[-1]
+    df_updated_summary['waveform_id'] = df_updated_summary['waveform'].str.split('/').str[-1]
+
+    # Reorder the columns
+    df_updated_summary = df_updated_summary[['test', 'waveform', 'waveform_id', 'format', 'format_id', 'result']]
+
+    df_updated_summary.to_csv(summary_file, index=False)
 
 
 def main():
@@ -26,6 +75,9 @@ def main():
     ap.add_argument('--waveform_suite_table', '-s',
                     default=None,
                     help='A csv table with input_record, physionet directory, and format class for multiple files')
+    ap.add_argument('--waveform_suite_summary_file', '-w',
+                    default=None,
+                    help='Save a CSV summary of the waveform suite run to this path/file')
     opts = ap.parse_args()
 
     # Check conditions based on the parsed arguments
@@ -34,18 +86,25 @@ def main():
         if opts.input_record is None or opts.format_class is None:
             ap.error('--input_record and --format_class are required unless --waveform_suite_table is specified')
 
-    # If a table with multiple files is passed we loop through it
+    # If a table with multiple files is passed we loop through it and save a summary of the results
     if opts.waveform_suite_table:
         waveform_suite = read_csv(opts.waveform_suite_table)
+
+        format_list, waveform_list, test_list, result_list = init_summary_file(opts.waveform_suite_summary_file)
 
         for waveform_file in waveform_suite:
             record = waveform_file[0]
             format = waveform_file[1]
             pn_dir = waveform_file[2]
-            run_benchmarks(input_record=record,
-                           format_class=format,
-                           pn_dir=pn_dir
-                           )
+            # summary_file = opts.waveform_suite_summary_file
+            format_list, waveform_list, test_list, result_list = run_benchmarks(input_record=record,
+                                                                                format_class=format, pn_dir=pn_dir,
+                                                                                format_list=format_list,
+                                                                                waveform_list=waveform_list,
+                                                                                test_list=test_list,
+                                                                                result_list=result_list)
+
+        save_summary(format_list, waveform_list, test_list, result_list, opts.waveform_suite_summary_file)
 
     # Run benchmarking against a single file
     else:

--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -3,6 +3,7 @@
 import importlib
 import os
 import random
+import sys
 import tempfile
 
 import numpy as np
@@ -14,6 +15,9 @@ from waveform_benchmark.utils import median_attr
 
 
 def append_result(format_name, waveform_name, test_name, result, format_list, waveform_list, test_list, result_list):
+    """
+    Add a result to the summary lists
+    """
     format_list.append(format_name)
     waveform_list.append(waveform_name)
     test_list.append(test_name)
@@ -24,6 +28,7 @@ def append_result(format_name, waveform_name, test_name, result, format_list, wa
 
 def run_benchmarks(input_record, format_class, pn_dir=None, format_list=None, waveform_list=None, test_list=None,
                    result_list=None):
+
     # Load the class we will be testing
     module_name, class_name = format_class.rsplit('.', 1)
     module = importlib.import_module(module_name)


### PR DESCRIPTION
This PR helps to summarize benchmarking runs by doing the following:

- Provide an option to save all of the print messages to a .log file
- For runs across multiple files:
  - save a subset of the result to a CSV table or append results to an already existing version of the CSV table.
  - add a progress bar. 