### PR TITLE
Benchmarking - handle all NaN signal for WFDB `write_waveform` format

### DIFF
--- a/waveform_benchmark/formats/wfdb.py
+++ b/waveform_benchmark/formats/wfdb.py
@@ -43,12 +43,15 @@ class BaseWFDBFormat(BaseFormat):
                 sig_samples[start:end] = chunk['samples']
                 sig_gain = max(sig_gain, chunk['gain'])
 
-            if all(numpy.isnan(sig_samples)):
+            # Determine the minimum and maximum non-NaN sample values.
+            # (nanmin and nanmax will give a warning if all values are NaN.)
+            sample_min = numpy.fmin.reduce(sig_samples)
+            sample_max = numpy.fmax.reduce(sig_samples)
+            if numpy.isnan(sample_min):
                 sig_baseline = 0
             else:
-                sample_min = numpy.nanmin(sig_samples)
-                sample_max = numpy.nanmax(sig_samples)
                 sig_baseline = round(-sig_gain * (sample_min + sample_max) / 2)
+
             adc_gain.append(sig_gain)
             baseline.append(sig_baseline)
             e_p_signal.append(sig_samples)

--- a/waveform_benchmark/formats/wfdb.py
+++ b/waveform_benchmark/formats/wfdb.py
@@ -43,9 +43,12 @@ class BaseWFDBFormat(BaseFormat):
                 sig_samples[start:end] = chunk['samples']
                 sig_gain = max(sig_gain, chunk['gain'])
 
-            sample_min = numpy.nanmin(sig_samples)
-            sample_max = numpy.nanmax(sig_samples)
-            sig_baseline = round(-sig_gain * (sample_min + sample_max) / 2)
+            if all(numpy.isnan(sig_samples)):
+                sig_baseline = 0
+            else:
+                sample_min = numpy.nanmin(sig_samples)
+                sample_max = numpy.nanmax(sig_samples)
+                sig_baseline = round(-sig_gain * (sample_min + sample_max) / 2)
             adc_gain.append(sig_gain)
             baseline.append(sig_baseline)
             e_p_signal.append(sig_samples)


### PR DESCRIPTION
If a requested section of a signal was composed of all NaNs, the WFDB `write_waveform` function would fail with this error:

```
Traceback (most recent call last):
  File "/chorus_waveform/./waveform_benchmark.py", line 6, in <module>
    waveform_benchmark.__main__.main()
  File "/chorus_waveform/waveform_benchmark/__main__.py", line 110, in main
    format_list, waveform_list, test_list, result_list = run_benchmarks(input_record=record,
                                                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/chorus_waveform/waveform_benchmark/benchmark.py", line 114, in run_benchmarks
    fmt().write_waveforms(path, waveforms)
  File "/chorus_waveform/waveform_benchmark/formats/wfdb.py", line 48, in write_waveforms
    sig_baseline = round(-sig_gain * (sample_min + sample_max) / 2)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
ValueError: cannot convert float NaN to integer
```

This was occurring with this waveform: `mimic3wdb/1.0/36/3654093/3654093`. This PR first checks to see if the requested signal is composed of all NaNs. If it is, `sig_baseline` is set to 0. If it isn't, the baseline is set as was being done previously.  