### PR TITLE
Work around "psf_fseek" bug

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ jpy==0.16.0
 python-dotenv==1.0.1
 zarr==2.17.2
 
+# Workaround https://github.com/MIT-LCP/wfdb-python/issues/486
+soundfile==0.11.0


### PR DESCRIPTION
Something's wrong with the `soundfile` wheel packages for x86-64 Linux: https://github.com/MIT-LCP/wfdb-python/issues/486

An example is:
```
waveform_benchmark.py --input_record 82284982 --physionet_directory mimic4wdb/0.1.0/waves/p169/p16955095/82284982 --format_class waveform_benchmark.formats.wfdb.WFDBFormat516
```
I think this probably not a bug in wfdb.  I'm not sure what the problem is exactly.

As a workaround, pin the soundfile package to an older version (https://pypi.org/project/soundfile/0.11.0/).
