### PR TITLE
Update code to resolve Fidelity check errors

### DIFF
--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -174,7 +174,7 @@ def run_benchmarks(input_record, format_class, pn_dir=None, format_list=None, wa
                 filedata_nonan = filedata[~np.isnan(data)]
 
                 # use numpy's isclose to determine floating point equality
-                isgood = np.isclose(filedata_nonan,data_nonan)
+                isgood = np.isclose(filedata_nonan,data_nonan,atol=0.5/chunk['gain'])
                 numgood = np.sum(isgood)
                 fpeq_rel = numgood/len(data_nonan)
                 

--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -174,7 +174,7 @@ def run_benchmarks(input_record, format_class, pn_dir=None, format_list=None, wa
                 filedata_nonan = filedata[~np.isnan(data)]
 
                 # use numpy's isclose to determine floating point equality
-                isgood = np.isclose(filedata_nonan,data_nonan,atol=0.5/chunk['gain'])
+                isgood = np.isclose(filedata_nonan, data_nonan, atol=0.5/chunk['gain'])
                 numgood = np.sum(isgood)
                 fpeq_rel = numgood/len(data_nonan)
                 

--- a/waveform_benchmark/formats/ccdef.py
+++ b/waveform_benchmark/formats/ccdef.py
@@ -41,6 +41,7 @@ class BaseCCDEF(BaseFormat):
                 sig_samples = np.empty(sig_length, dtype=np.short)
                 nanval = -32768
                 sig_samples[:] = nanval
+                max_gain = max(chunk['gain'] for chunk in chunks)
 
                 # TODO: store time as segments of sample, starttime, length
 
@@ -49,10 +50,10 @@ class BaseCCDEF(BaseFormat):
                     end = chunk['end_sample']
 
                     cursamples = np.where(np.isnan(chunk['samples']),
-                                          (nanval*1.0)/chunk["gain"],
+                                          (nanval*1.0)/max_gain,
                                           chunk['samples'])
 
-                    sig_samples[start:end] = np.round(cursamples*chunk["gain"])
+                    sig_samples[start:end] = np.round(cursamples * max_gain)
 
                 if self.fmt == "Compressed":
                     f["Waveforms"].create_dataset(channel,
@@ -67,7 +68,7 @@ class BaseCCDEF(BaseFormat):
                 f["Waveforms"][channel].attrs["uom"] = datadict["units"]
                 f["Waveforms"][channel].attrs["sample_rate"] = datadict["samples_per_second"]
                 f["Waveforms"][channel].attrs["nanvalue"] = nanval
-                f["Waveforms"][channel].attrs["gain"] = chunks[0]["gain"]
+                f["Waveforms"][channel].attrs["gain"] = max_gain
                 f["Waveforms"][channel].attrs["start_time"] = chunks[0]["start_time"]
 
     def read_waveforms(self, path, start_time, end_time, signal_names):


### PR DESCRIPTION
This PR makes two updates to resolve the Fidelity check errors mentioned in https://github.com/chorus-ai/chorus_waveform/issues/62:

1. It changes the tolerance used during the fidelity check to be based on the bit resolution of the signal
2. It uses the max gain across segments for CCDEF

This update does not appear to be related to the Fidelity check error for CCDEF in https://github.com/chorus-ai/chorus_waveform/issues/64