### PR TITLE
Restore "zarr format compressed signal handler added" commit

### DIFF
--- a/waveform_benchmark/formats/zarr.py
+++ b/waveform_benchmark/formats/zarr.py
@@ -43,3 +43,45 @@ class Zarr(BaseFormat):
             results[signal_name] = ds[start_sample:end_sample]
 
         return results
+
+class Zarr_compressed(BaseFormat):
+    """
+    Example format using Zarr with compression.
+    """
+
+    def write_waveforms(self, path, waveforms):
+        # Initialize Zarr group 
+        root_group = zarr.open_group(path, mode='w')
+
+        for name, waveform in waveforms.items():
+            length = waveform['chunks'][-1]['end_sample']
+            samples = np.empty(length, dtype=np.float32)
+            samples[:] = np.nan 
+
+            for chunk in waveform['chunks']:
+                start = chunk['start_sample']
+                end = chunk['end_sample']
+                samples[start:end] = chunk['samples']
+
+            # each waveform within the root group with compression.
+            ds = root_group.create_dataset(name, data=samples, chunks=True, dtype=np.float32, compressor=zarr.Blosc(cname='zstd', clevel=9, shuffle=zarr.Blosc.BITSHUFFLE))
+            ds.attrs['units'] = waveform['units']
+            ds.attrs['samples_per_second'] = waveform['samples_per_second']
+
+
+    def read_waveforms(self, path, start_time, end_time, signal_names):
+        # Open the Zarr group
+        root_group = zarr.open_group(path, mode='r')
+
+        results = {}
+        for signal_name in signal_names:
+            ds = root_group[signal_name]
+            samples_per_second = ds.attrs['samples_per_second']
+            
+            start_sample = round(start_time * samples_per_second)
+            end_sample = round(end_time * samples_per_second)
+            
+            # Random access the Zarr array 
+            results[signal_name] = ds[start_sample:end_sample]
+
+        return results


### PR DESCRIPTION
The `Zarr_compressed` class is no longer in the `main` branch even though it had been added by https://github.com/chorus-ai/chorus_waveform/commit/5793fbc944c2d70b3860e24ee64ea05eb8abfcbc . Doing a bisect shows:

```
chorus_waveform$ git bisect start
status: waiting for both good and bad commits
chorus_waveform$ git bisect bad HEAD
status: waiting for good commit(s), bad commit known
chorus_waveform$ git bisect good 5793fbc
Bisecting: a merge base must be tested
[dbe2f709a00ae7c3755e1fc6a7acba0211978a4b] removes parquet handler
```

However, looking at https://github.com/chorus-ai/chorus_waveform/commit/dbe2f709a00ae7c3755e1fc6a7acba0211978a4b and https://github.com/chorus-ai/chorus_waveform/pull/39/files it isn't clear to me that "removes parquet handler" should have deleted `Zarr_compressed`. 