### PR TITLE
DICOM Fidelity Check failure

### DIFF
--- a/BENCHMARK.md
+++ b/BENCHMARK.md
@@ -9,7 +9,7 @@ The benchmarking script includes a simple set of metrics to evaluate the perform
 The [waveform_benchmark.py](./waveform_benchmark.py) script is the entrypoint for running benchmarks. This script calls functions in the `waveform_benchmark` package. The syntax for running waveform_benchmark.py from the command line is: 
 
 ```
-./waveform_benchmark.py -r <PATH_TO_RECORD> -f <PATH_TO_BENCHMARK_CLASS> -p <PHYSIONET_DATABASE_PATH>
+./waveform_benchmark.py -r <PATH_TO_RECORD> -f <PATH_TO_BENCHMARK_CLASS> -p <PHYSIONET_DATABASE_PATH> [--test_only]
 ```
 
 The `-p` argument can be used to pull a file directly from a PhysioNet database but isn't needed when running on a local file. For example, to run the `WFDBFormat516` benchmark on local record `data/waveforms/mimic_iv/waves/p100/p10079700/85594648/85594648`:
@@ -17,6 +17,8 @@ The `-p` argument can be used to pull a file directly from a PhysioNet database 
 ```
 ./waveform_benchmark.py -r ./data/waveforms/mimic_iv/waves/p100/p10079700/85594648/85594648 -f waveform_benchmark.formats.wfdb.WFDBFormat516
 ```
+
+The `--test_only` flag can be used to turn off the read performance benchmarking thus run only the fidelity tests.
 
 An example output is provided below:
 

--- a/waveform_benchmark/__main__.py
+++ b/waveform_benchmark/__main__.py
@@ -82,6 +82,9 @@ def main():
     ap.add_argument('--waveform_suite_summary_file', '-w',
                     default='waveform_suite_benchmark_summary.csv',
                     help='Save a CSV summary of the waveform suite run to this path/file')
+    ap.add_argument('--test_only', 
+                    default=False, action='store_true',
+                    help='Run only the tests, do not run the benchmarks')
     opts = ap.parse_args()
 
     # If log is requested send the output there
@@ -121,7 +124,8 @@ def main():
     else:
         run_benchmarks(input_record=opts.input_record,
                        format_class=opts.format_class,
-                       pn_dir=opts.physionet_directory)
+                       pn_dir=opts.physionet_directory,
+                       test_only = opts.test_only)
 
     # Close the log file after the run is complete
     if opts.save_output_to_log:

--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -206,7 +206,7 @@ def run_benchmarks(input_record, format_class, pn_dir=None, format_list=None, wa
                 # use numpy's isclose to determine floating point equality
                 isgood = np.isclose(filedata_nonan, data_nonan, atol=0.5/chunk['gain'])
                 numgood = np.sum(isgood)
-                fpeq_rel = numgood/len(data_nonan)
+                fpeq_rel = numgood/len(data_nonan) if len(data_nonan) != 0 else np.nan
 
                 # compute SNR to quantify signal fidelity
                 snr = compute_snr(data_nonan, filedata_nonan)

--- a/waveform_benchmark/formats/dcm_utils/dcm_waveform_reader.py
+++ b/waveform_benchmark/formats/dcm_utils/dcm_waveform_reader.py
@@ -180,15 +180,21 @@ def get_multiplex_array(fileobj : BinaryIO,
             baseline = float(ch.ChannelBaseline)
             sensitivity = float(ch.ChannelSensitivity)
             correction = float(ch.ChannelSensitivityCorrectionFactor)
+            # nominal = v * gain = (encoded * sensitivity - baseline)   -  see reader.
+            # v = nominal * correction
             adjustment = sensitivity * correction
-            if (adjustment != 1.0) and (baseline != 0.0):
-                arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] * adjustment + baseline)
-            elif (adjustment != 1.0):
-                arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] * adjustment)
-            elif (baseline != 0.0):
-                arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] + baseline)
+            base = baseline * correction
+            # print(" reading ", ch_idx, sensitivity, baseline, correction, adjustment, base)
+            if (adjustment != 1.0):
+                if (base != 0.0):
+                    arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] * adjustment - base)
+                else:
+                    arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] * adjustment)
             else:
-                arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...])
+                if (base != 0.0):
+                    arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] - base)
+                else:
+                    arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...])
 
 
     return cast("np.ndarray", arr)

--- a/waveform_benchmark/formats/dcm_utils/dcm_waveform_reader.py
+++ b/waveform_benchmark/formats/dcm_utils/dcm_waveform_reader.py
@@ -175,27 +175,29 @@ def get_multiplex_array(fileobj : BinaryIO,
         chseq = cast(list["Dataset"], channel_seqs)
         
         # Apply correction factor (if possible)
+        padd_loc = (arr == padding_value)
         arr = arr.astype("float")
         for ch_idx, ch in enumerate(chseq):
             baseline = float(ch.ChannelBaseline)
             sensitivity = float(ch.ChannelSensitivity)
             correction = float(ch.ChannelSensitivityCorrectionFactor)
-            # nominal = v * gain = (encoded * sensitivity - baseline)   -  see reader.
-            # v = nominal * correction
+            
+            # print("baseline " + str(baseline) + " sensitivity " + str(sensitivity) + " correction " + str(correction)) 
+
             adjustment = sensitivity * correction
-            base = baseline * correction
+            base = baseline
             # print(" reading ", ch_idx, sensitivity, baseline, correction, adjustment, base)
             if (adjustment != 1.0):
                 if (base != 0.0):
-                    arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] * adjustment - base)
+                    arr[ch_idx, ...] = np.where(padd_loc[ch_idx, ...], np.nan, arr[ch_idx, ...] * adjustment - base)
                 else:
-                    arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] * adjustment)
+                    arr[ch_idx, ...] = np.where(padd_loc[ch_idx, ...], np.nan, arr[ch_idx, ...] * adjustment)
             else:
                 if (base != 0.0):
-                    arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...] - base)
+                    arr[ch_idx, ...] = np.where(padd_loc[ch_idx, ...], np.nan, arr[ch_idx, ...] - base)
                 else:
-                    arr[ch_idx, ...] = np.where(arr[ch_idx, ...] == padding_value, np.nan, arr[ch_idx, ...])
-
+                    arr[ch_idx, ...] = np.where(padd_loc[ch_idx, ...], np.nan, arr[ch_idx, ...])
+            # print(ch.ChannelSourceSequence[0].CodeMeaning + " sensitivity " + str(sensitivity) + " gain = " + str(1.0 / sensitivity) + " baseline = " + str(baseline) + " correction = " + str(correction)) 
 
     return cast("np.ndarray", arr)
 

--- a/waveform_benchmark/formats/dcm_utils/dcm_waveform_writer.py
+++ b/waveform_benchmark/formats/dcm_utils/dcm_waveform_writer.py
@@ -133,7 +133,7 @@ class DICOMWaveformIOD:
 
     
 class TwelveLeadECGWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
+    def __init__(self, bits: int = 16, num_channels: int = None):
         pass
         
     VR = DICOMWaveform16
@@ -158,8 +158,8 @@ class TwelveLeadECGWaveform(DICOMWaveformIOD):
     
 # 4 groups, 1 to 24 channels each. unknown sample count limit., f in 200-1000
 class GeneralECGWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
-        if hifi:
+    def __init__(self, bits: int = 16, num_channels: int = None):
+        if bits > 16:
             self.VR = DICOMWaveform32
             self.storage_uid = '1.2.840.10008.5.1.4.1.1.9.1.4'
         else:
@@ -186,7 +186,7 @@ class GeneralECGWaveform(DICOMWaveformIOD):
     
 
 class AmbulatoryECGWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
+    def __init__(self, bits : int = 16, num_channels: int = None):
         pass
         
     # 8bit allowed, but gain may be too high for 8 bit
@@ -198,7 +198,7 @@ class AmbulatoryECGWaveform(DICOMWaveformIOD):
     }
 
 class CardiacElectrophysiologyWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
+    def __init__(self, bits : int = 16, num_channels: int = None):
         pass
     
     VR = DICOMWaveform16
@@ -210,7 +210,7 @@ class CardiacElectrophysiologyWaveform(DICOMWaveformIOD):
 
 # max 4 sequences, up to 8 channels each, num of samples limited by waveform maxsize. f < 400,
 class HemodynamicWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
+    def __init__(self, bits : int = 16, num_channels: int = None):
         pass
     
     VR = DICOMWaveform16
@@ -232,8 +232,8 @@ class HemodynamicWaveform(DICOMWaveformIOD):
     
 # max 1 sequence, 1 wave each. unknown sample count limit. f < 600.
 class ArterialPulseWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
-        # if hifi:
+    def __init__(self, bits : int = 16, num_channels: int = None):
+        # if bits > 8:
         #     self.VR = DICOMWaveform16
         # else:
         #     self.VR = DICOMWaveform8
@@ -253,9 +253,9 @@ class ArterialPulseWaveform(DICOMWaveformIOD):
     
 # different IOD for multiple channels.  1 multplex group, 1 channel each. unknown sample count limit. f < 100.
 class RespiratoryWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
+    def __init__(self, bits : int = 16, num_channels: int = None):
         if num_channels <= 1:
-            # if hifi:
+            # if bits > 8:
             #     self.VR = DICOMWaveform16
             # else:
             #     self.VR = DICOMWaveform8
@@ -263,7 +263,7 @@ class RespiratoryWaveform(DICOMWaveformIOD):
             self.VR = DICOMWaveform16
             self.storage_uid = uid.RespiratoryWaveformStorage
         elif num_channels > 1:
-            if hifi:
+            if bits > 16:
                 self.VR = DICOMWaveform32
             else:
                 self.VR = DICOMWaveform16
@@ -280,8 +280,8 @@ class RespiratoryWaveform(DICOMWaveformIOD):
     }
         
 class RoutineScalpEEGWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
-        if hifi:
+    def __init__(self, bits : int = 16, num_channels: int = None):
+        if bits > 16:
             self.VR = DICOMWaveform32
         else:
             self.VR = DICOMWaveform16
@@ -294,8 +294,8 @@ class RoutineScalpEEGWaveform(DICOMWaveformIOD):
 
 # unlimited number of multiplex groups, up to 64 channels each.  sample size and f unconstrained.
 class SleepEEGWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
-        if hifi:
+    def __init__(self, bits : int = 16, num_channels: int = None):
+        if bits > 16:
             self.VR = DICOMWaveform32
         else:
             self.VR = DICOMWaveform16
@@ -314,8 +314,8 @@ class SleepEEGWaveform(DICOMWaveformIOD):
     
 #unlimited multiplex groups, up to 64 channels each.  sample size and f unconstrained.
 class ElectromyogramWaveform(DICOMWaveformIOD):
-    def __init__(self, hifi: bool = False, num_channels: int = None):
-        if hifi:
+    def __init__(self, bits : int = 16, num_channels: int = None):
+        if bits > 16:
             self.VR = DICOMWaveform32
         else:
             self.VR = DICOMWaveform16

--- a/waveform_benchmark/formats/dcm_utils/dcm_waveform_writer.py
+++ b/waveform_benchmark/formats/dcm_utils/dcm_waveform_writer.py
@@ -8,11 +8,13 @@ from typing import TYPE_CHECKING, cast
 
 import math
 from datetime import datetime
+import decimal
 
 import warnings
-# warnings.filterwarnings("error")
 
 from waveform_benchmark.formats.base import BaseFormat
+
+# dicom3tools currently does NOT validate the IODs for waveform.  IT does validate the referencedSOPClassUIDInFile in DICOMDIR file.
 
 # types of waveforms and constraints:  
 #   https://dicom.nema.org/medical/dicom/current/output/chtml/part03/PS3.3.html
@@ -80,20 +82,20 @@ class DICOMWaveformVR:
 class DICOMWaveform8(DICOMWaveformVR):
     WaveformBitsAllocated = 8
     WaveformSampleInterpretation = "SB"
-    PaddingValue = int(-128)
     PythonDatatype = np.int8
+    PaddingValue = np.iinfo(PythonDatatype).min
                
 class DICOMWaveform16(DICOMWaveformVR):
     WaveformBitsAllocated = 16
     WaveformSampleInterpretation = "SS"
-    PaddingValue = int(-32768)
     PythonDatatype = np.int16
+    PaddingValue = np.iinfo(PythonDatatype).min
     
 class DICOMWaveform32(DICOMWaveformVR):
     WaveformBitsAllocated = 32
     WaveformSampleInterpretation = "SL"
-    PaddingValue = int(-2147483648)
     PythonDatatype = np.int32
+    PaddingValue = np.iinfo(PythonDatatype).min
 
 
 # relevant definitions:
@@ -259,14 +261,14 @@ class RespiratoryWaveform(DICOMWaveformIOD):
             #     self.VR = DICOMWaveform8
             # 8bit allowed, but gain may be too high for 8 bit
             self.VR = DICOMWaveform16
-            storage_uid = uid.RespiratoryWaveformStorage
+            self.storage_uid = uid.RespiratoryWaveformStorage
         elif num_channels > 1:
             if hifi:
                 self.VR = DICOMWaveform32
             else:
                 self.VR = DICOMWaveform16
-            storage_uid = uid.MultichannelRespiratoryWaveformStorage
-                    
+            self.storage_uid = uid.MultichannelRespiratoryWaveformStorage
+                                        
     modality = 'RESP'
     channel_coding = {
         'RESP': {'group': 1, 'scheme': 'SCPECG', 'value': '5.6.3-9-01', 'meaning': 'Respiration'},
@@ -448,11 +450,12 @@ class DICOMWaveformWriter:
     
     
     # channel_chunks is a list of tuples (channel, chunk).
-    # 
+    # minmax is a dict of channel to (min, max)
     def create_multiplexed_chunk(self, waveforms: dict, 
                                  iod: DICOMWaveformIOD, 
                                  group: int,
                                  channel_chunk: list,
+                                 minmax: dict,
                                  start_time: float,
                                  end_time: float):
                 
@@ -525,6 +528,11 @@ class DICOMWaveformWriter:
                           dtype=iod.VR.PythonDatatype)
         # now collect the chunks into an array, generate the multiplex group, and increment the chunk ids.
         unprocessed_chunks.sort(key=lambda x: (x[0], x[3], x[4])) # ordered by channel
+        # using  90% of the dynamic range to avoid overflow
+        out_min = np.round(float(iod.VR.PaddingValue) * 0.9)
+        out_max = np.round(float(np.iinfo(iod.VR.PythonDatatype).max) * 0.9)
+        
+        gains = {}
         for channel, chunk_id, start_src, start_target, end_target in unprocessed_chunks: 
             
             chunk = waveforms[channel]['chunks'][chunk_id]
@@ -537,15 +545,39 @@ class DICOMWaveformWriter:
             # values is in original type.  nan replaced with PaddingValue then will be multiplied by gain, so divide here to avoid overflow.
             # values = np.nan_to_num(np.frombuffer(chunk['samples'][start_src:end_src], dtype=np.dtype(chunk['samples'].dtype)), 
             #                        nan = float(iod.VR.PaddingValue) / float(chunk['gain']) )
+            # per dicom standard 
+            #   channelSensitivity is gain * adc resolution
+            #   datavalue * channelsensitivity = nominal value in unit specified.  should match input.
+            #   nominal value * sensitivity correction factor = actual value.
+            #    
+            
+            # get the input values
             v = np.frombuffer(chunk['samples'][start_src:end_src], dtype=np.dtype(chunk['samples'].dtype))
-            gain = float(chunk['gain'])
-            values = np.where(np.isnan(v), float(iod.VR.PaddingValue), v * gain)
-
-
+            min_v = float(minmax[channel][0])
+            max_v = float(minmax[channel][1])
+            
+            # sensitivity, baseline, and scaling factor:
+            # encoded = (input - min(input)) / (max(input) - min(input)) * (max(output) - min(output)) + min(output)
+            #           = input * scale1 + min(output) - min(input) * scale1 
+            #           = input * scale1 + baseline
+            #  where scale1 = (max(output) - min(output)) / (max(input) - min(input), 
+            scale1 = (out_max - out_min) / (max_v - min_v)
+            #        baseline = min(output) - min(input) * scale1
+            base1 = out_min - min_v * scale1
+            
             chan_id = channels[channel]
+            samples[chan_id][start_target:end_target] = np.where(np.isnan(v), float(iod.VR.PaddingValue), np.round(v * scale1 + base1, decimals=0)).astype(iod.VR.PythonDatatype)
+            # nominal data = input * gain = (encoded - baseline) / scale1 * gain
+            #             = encoded * scale2 - baseline2
+            #  where scale2 = gain / scale1, baseline2 = baseline * scale2 
+            
+            if channel not in gains.keys():
+                gains[channel] = set()
+            gains[channel].add(float(chunk['gain']))
+
             # write out in integer format
             # samples[chan_id][start_target:end_target] = np.round(values * float(chunk['gain']), decimals=0).astype(iod.VR.PythonDatatype)
-            samples[chan_id][start_target:end_target] = np.round(values, decimals=0).astype(iod.VR.PythonDatatype)
+            # samples[chan_id][start_target:end_target] = np.round(values, decimals=0).astype(iod.VR.PythonDatatype)
             # print("chunk shape:", chunk['samples'].shape)
             # print("values shape: ", values.shape)
             # print("samples shape: ", samples.shape)
@@ -579,7 +611,21 @@ class DICOMWaveformWriter:
             source.CodingSchemeVersion = "unknown"
             source.CodeMeaning = channel
                 
-            chdef.ChannelSensitivity = 1.0
+            
+            if len(gains[channel]) > 1:
+                print("ERROR: Different gains for the same channel is not supported. ", gains[channel])
+            gain = gains[channel].pop()
+            
+            # actual data = nominal data / gain.
+            # baseline:  standards def: offset of encoded sample value 0 from actual (nonimal) 0 in same unit as nominal
+            #       set as baseline2
+            # sensitivity = scale2
+            # sensitivity correction factor would be 1/gain, so we can recover gain.
+            sens_corr = str(decimal.Decimal(1.0 / gain))
+            
+            scale1inv = (minmax[channel][1] - minmax[channel][0]) / (out_max - out_min)
+            sensitivity = str(decimal.Decimal(gain * scale1inv))
+            chdef.ChannelSensitivity = sensitivity if len(sensitivity) <= 16 else sensitivity[:16]   # gain and ADC resolution goes here
             chdef.ChannelSensitivityUnitsSequence = [Dataset()]
             units = chdef.ChannelSensitivityUnitsSequence[0]
                 
@@ -590,14 +636,20 @@ class DICOMWaveformWriter:
             units.CodeMeaning = UCUM_ENCODING[unit]  # this needs to be fixed.
                 
             # multiplier to apply to the encoded value to get back the orginal input.
-            ds = str(float(1.0) / float(chunk['gain']))
-            chdef.ChannelSensitivityCorrectionFactor = ds if len(ds) <= 16 else ds[:16]
-            chdef.ChannelBaseline = '0'
+            chdef.ChannelSensitivityCorrectionFactor = sens_corr if len(sens_corr) <= 16 else sens_corr[:16]
+            # Offset of encoded sample value 0 from actual 0 using the units defined in the Channel Sensitivity Units Sequence (003A,0211).
+            # baseline2 = baseline * scale2 = baseline * gain * scale1inv = (min(output) - min(input) * scale1) * gain * scale1inv
+            #   = min(output) * gain * scale1inv   - min(input) * gain
+            #   = min(output) * sensitivity - min(input) * gain
+            # nom data = encoded * scale2 - baseline2
+            baseln = str(decimal.Decimal((out_min * scale1inv - minmax[channel][0]) * gain))
+            chdef.ChannelBaseline = baseln if len(baseln) <= 16 else baseln[:16]
+                        
             chdef.WaveformBitsStored = iod.VR.WaveformBitsAllocated
             # only for amplifier type of AC
             # chdef.FilterLowFrequency = '0.05'
             # chdef.FilterHighFrequency = '300'
-            channeldefs[channel] = chdef            
+            channeldefs[channel] = chdef
             
 
         wfDS.ChannelDefinitionSequence = channeldefs.values() 
@@ -608,10 +660,12 @@ class DICOMWaveformWriter:
         return wfDS
 
     
+    # minmax is dictionary of channel to (min, max) values
     def add_waveform_chunks_multiplexed(self, dataset,
                                         iod: DICOMWaveformIOD,
                                         chunk_info: dict,
-                                        waveforms: dict):
+                                        waveforms: dict,
+                                        minmax: dict):
         
         # dicom waveform -> sequence of multiplex group -> channels with same sampling frequency
         # multiplex group can have labels.
@@ -629,7 +683,7 @@ class DICOMWaveformWriter:
         
         for group, chanchunks in grouped_channels.items():
             # input to this is [(channel, chunk), ... ]
-            multiplexGroupDS = self.create_multiplexed_chunk(waveforms, iod, group, chanchunks, 
+            multiplexGroupDS = self.create_multiplexed_chunk(waveforms, iod, group, chanchunks, minmax,
                                                             start_time=start_time, end_time=end_time)
             dataset.WaveformSequence.append(multiplexGroupDS)        
         

--- a/waveform_benchmark/formats/dcm_utils/dcm_waveform_writer.py
+++ b/waveform_benchmark/formats/dcm_utils/dcm_waveform_writer.py
@@ -501,8 +501,10 @@ class DICOMWaveformWriter:
                         
             # only process if there is finite data.        
             temp_data = waveforms[channel]['chunks'][chunkid]['samples'][channel_start:channel_start+duration]
-            if (temp_data is None) or (len(temp_data) == 0) or (not np.any(np.isfinite(temp_data))):
-                continue 
+            if (temp_data is None) or (len(temp_data) == 0):
+                continue
+            # in case it's all nans or infs
+            all_nan = (not np.any(np.isfinite(temp_data)))
 
             # assign ids for each channel
             if channel not in channels.keys():
@@ -512,8 +514,8 @@ class DICOMWaveformWriter:
                 gains[channel] = []
                 i += 1
 
-            mins[channel].append(np.fmin.reduce(temp_data))
-            maxs[channel].append(np.fmax.reduce(temp_data))
+            mins[channel].append(0 if all_nan else np.fmin.reduce(temp_data))
+            maxs[channel].append(0 if all_nan else np.fmax.reduce(temp_data))
             gains[channel].append(waveforms[channel]['chunks'][chunkid]['gain'])
             unprocessed_chunks.append((channel, chunkid, channel_start, target_start, target_start + duration))
 

--- a/waveform_benchmark/formats/dicom.py
+++ b/waveform_benchmark/formats/dicom.py
@@ -188,6 +188,7 @@ class BaseDICOMFormat(BaseFormat):
                              'end_time': chunk['end_time'], 
                             #  'start_sample': chunk['start_sample'], 
                             #  'end_sample': chunk['end_sample'],
+                             'gain': chunk['gain'],
                              'iod': iod.__name__,
                              'group': group,
                              'freq_id': None})
@@ -199,12 +200,13 @@ class BaseDICOMFormat(BaseFormat):
                              'end_time': chunk['end_time'], 
                             #  'start_sample': chunk['start_sample'], 
                             #  'end_sample': chunk['end_sample'],
+                             'gain': chunk['gain'],
                              'iod': iod.__name__,
                              'group': group,
                              'freq_id': None})
 
         df = pd.DataFrame(data)
-        df.sort_values(by=['iod', 'start_time', 'freq', 'chunk_id'], inplace=True)
+        df.sort_values(by=['iod', 'start_time', 'freq', 'gain', 'chunk_id'], inplace=True)
 
         # assign freq_id, one per frequency within a group
         sorted = df.groupby(['iod', 'group'])
@@ -286,57 +288,58 @@ class BaseDICOMFormat(BaseFormat):
         # do group by
         return out
 
-    # input:  list of dataframes, each dataframe is a group of channels with same iod, group, and frequency.
-    # return: dict, each entry is (iod, group, freq, id) = {start_t, end_t, [{(channel, chunk_id): (s_time, e_time), ...]}.  each chunk is defined as the max span for a set of channels.
-    # this is detected via a stack - when stack is empty, a subchunk is created.  note that chunkids are not aligned between channels
-    def split_chunks_temporal_merged(self, chunk_table: pd.DataFrame) -> dict:
-        # split the chunks so that each is a collection of channels in a group.
-        # fill missing channels with zeros
-        # need an ordering of channel starting and ending
-        # create new table with time stamp, and chunk id (- for start, + for end)
-        # sort in order:  iod, group, freq, timestamp, chunk id
-        # iterate and push and pop to queue (parenthesis like). create a chunk when queue becomes empty.
+    # # Deprecate - this does not work if there are multiple gains in the same chunk.   
+    # # input:  list of dataframes, each dataframe is a group of channels with same iod, group, and frequency.
+    # # return: dict, each entry is (iod, group, freq, id) = {start_t, end_t, [{(channel, chunk_id): (s_time, e_time), ...]}.  each chunk is defined as the max span for a set of channels.
+    # # this is detected via a stack - when stack is empty, a subchunk is created.  note that chunkids are not aligned between channels
+    # def split_chunks_temporal_merged(self, chunk_table: pd.DataFrame) -> dict:
+    #     # split the chunks so that each is a collection of channels in a group.
+    #     # fill missing channels with zeros
+    #     # need an ordering of channel starting and ending
+    #     # create new table with time stamp, and chunk id (- for start, + for end)
+    #     # sort in order:  iod, group, freq, timestamp, chunk id
+    #     # iterate and push and pop to queue (parenthesis like). create a chunk when queue becomes empty.
 
-        chunk_table.sort_values(by=['iod', 'freq_id', 'start_time', 'chunk_id'], inplace=True)
-        sorted = chunk_table.groupby(['iod', 'freq_id'])
+    #     chunk_table.sort_values(by=['iod', 'freq_id', 'gain', 'start_time', 'chunk_id'], inplace=True)
+    #     sorted = chunk_table.groupby(['iod', 'freq_id', 'gain'])
 
-        out = dict()
-        file_id = 0
-        stime = None
-        etime = None
-        stack = []
-        channel_chunk_list = dict()  # store the (channel, chunk_id)
-        for (iod, freq_id), df in sorted:
-            for index, row in df.iterrows():
-                # update first
-                etime = row['end_time']
-                if row['chunk_id'] < 0:
-                    stack.append((row['channel'], (-row['chunk_id']) - 1))  # start of chunk
-                    channel_chunk_list[(row['channel'], (-row['chunk_id']) - 1)] = row['group']  # add on insert only
-                    # save if needed
-                    if len(stack) == 1:
-                        # inserted first element in the stack
-                        stime = row['start_time']
-                elif row['chunk_id'] > 0:
-                    stack.remove((row['channel'], row['chunk_id'] - 1))  # end of chunk
-                    # update end time on remove only
-                    if len(stack) == 0:
-                        # everything removed from a stack. this indicates a subchunk is complete
-                        if len(channel_chunk_list) > 0:
-                            out[(iod, freq_id, file_id)] = {'start_t': stime, 'end_t': etime, 'channel_chunk': channel_chunk_list.copy()}
-                            file_id += 1
-                        channel_chunk_list = {}  # reset
-                        stime = None
-                        etime = None
-                else:
-                    print("ERROR:  chunk id is 0", row)
+    #     out = dict()
+    #     file_id = 0
+    #     stime = None
+    #     etime = None
+    #     stack = []
+    #     channel_chunk_list = dict()  # store the (channel, chunk_id)
+    #     for (iod, freq_id), df in sorted:
+    #         for index, row in df.iterrows():
+    #             # update first
+    #             etime = row['end_time']
+    #             if row['chunk_id'] < 0:
+    #                 stack.append((row['channel'], (-row['chunk_id']) - 1))  # start of chunk
+    #                 channel_chunk_list[(row['channel'], (-row['chunk_id']) - 1)] = row['group']  # add on insert only
+    #                 # save if needed
+    #                 if len(stack) == 1:
+    #                     # inserted first element in the stack
+    #                     stime = row['start_time']
+    #             elif row['chunk_id'] > 0:
+    #                 stack.remove((row['channel'], row['chunk_id'] - 1))  # end of chunk
+    #                 # update end time on remove only
+    #                 if len(stack) == 0:
+    #                     # everything removed from a stack. this indicates a subchunk is complete
+    #                     if len(channel_chunk_list) > 0:
+    #                         out[(iod, freq_id, file_id)] = {'start_t': stime, 'end_t': etime, 'channel_chunk': channel_chunk_list.copy()}
+    #                         file_id += 1
+    #                     channel_chunk_list = {}  # reset
+    #                     stime = None
+    #                     etime = None
+    #             else:
+    #                 print("ERROR:  chunk id is 0", row)
 
-        return out
+    #     return out
 
     # input:  list of dataframes, each dataframe is a group of channels with same iod, group, and frequency.
     # return: dict, each entry is (iod, group, freq, id) = {start_t, end_t, [(channel, chunk_id), ...]}.  each chunk is a fixed time period.
     # we should first detect the merged chunks then segment the chunks. 
-    def split_chunks_temporal_fixed(self, chunk_table: pd.DataFrame, duration_sec: float = 600.0) -> dict:
+    def split_chunks_temporal_fixed(self, chunk_table: pd.DataFrame, duration_sec: float = 3600.0) -> dict:
         # split the chunks so that each is a fixed length with appropriate grouping. some may have partial data
         # need an ordering of channel starting and ending.
         # create new table with time stamp, and chunk id (- for start, + for end)
@@ -349,7 +352,7 @@ class BaseDICOMFormat(BaseFormat):
         # sorted = self.split_chunks_temporal_merged(chunk_table)
         # # next process each subchunk:
 
-        chunk_table.sort_values(by=['iod', 'freq_id', 'start_time', 'chunk_id'], inplace=True)
+        chunk_table.sort_values(by=['iod', 'freq_id', 'gain', 'start_time', 'chunk_id'], inplace=True)
         sorted = chunk_table.groupby(['iod', 'freq_id'])
 
         # for each subchunk, get the start and end, and insert splitters.
@@ -377,6 +380,7 @@ class BaseDICOMFormat(BaseFormat):
                             'chunk_id': 0,  # note:  this will occur before the end time entries.
                             'start_time': splitter_time, 
                             'end_time': splitter_time,
+                            'gain': -1,
                             'iod': "any",
                             'group': -1,
                             'freq_id': -1})
@@ -401,7 +405,7 @@ class BaseDICOMFormat(BaseFormat):
                 if row['chunk_id'] < 0:
                     k = (row['channel'], (-row['chunk_id']) - 1)
                     stack.append(k)  # start of chunk
-                    added[k] = row['group']  # add on insert only
+                    added[k] = (row['group'], row['gain'])  # add on insert only
                     # save if needed
 
                 elif row['chunk_id'] > 0:
@@ -414,8 +418,30 @@ class BaseDICOMFormat(BaseFormat):
                     # everything removed from a stack. this indicates a subchunk is complete
                     if len(added) > 0:
                         splitter_end = row['start_time']
-                        out[(iod, freq_id, file_id)] = {'start_t': splitter_start, 'end_t': splitter_end, 'channel_chunk': added.copy()}
-                        file_id += 1
+                        
+                        # check for multiple gains for same channel.  Separate by gain
+                        gains = {}
+                        for (ch, _), (_, gain) in added.items():
+                            if ch not in gains.keys():
+                                gains[ch] = set()
+                            gains[ch].add(gain)
+                        # the number of files to create is the max number of gains for any channel
+                        nfiles = max([len(x) for x in gains.values()])
+                        # convert set to list
+                        gains = {ch: list(gains[ch]) for ch in gains.keys()}
+                        # now split the added dict by file id
+                        to_add_groups = []
+                        for i in range(nfiles):
+                            to_add_groups.append({})
+                        
+                        for (channel, chunk_id), (group, gain) in added.items():
+                            id = gains[channel].index(gain)
+                            to_add_groups[id][(channel, chunk_id)] = group                         
+                        
+                        for i in range(nfiles):
+                            out[(iod, freq_id, file_id)] = {'start_t': splitter_start, 'end_t': splitter_end, 'channel_chunk': to_add_groups[i].copy()}
+                            file_id += 1
+                            
                         splitter_start = splitter_end
                         # update he added list by any queued deletes.
                         for x in deleted:
@@ -448,15 +474,18 @@ class BaseDICOMFormat(BaseFormat):
             for k, v in value['channel_chunk'].items():
                 print("        ", k, v)
                 
-    # get channel min and max values, across chunks.
-    def _get_waveform_channel_minmax(self, waveforms):
-        minmax = {}
-        for channel, wf in waveforms.items():
-            mins = [ np.nanmin(chunk['samples']) for chunk in wf['chunks'] ]
-            maxs = [ np.nanmax(chunk['samples']) for chunk in wf['chunks'] ]
+    # # get channel min and max values, across chunks.
+    # def _get_waveform_channel_minmax(self, waveforms):
+    #     minmax = {}
+    #     for channel, wf in waveforms.items():
+    #         mins = [ np.fmin.reduce(chunk['samples']) for chunk in wf['chunks'] ]
+    #         maxs = [ np.fmax.reduce(chunk['samples']) for chunk in wf['chunks'] ]
+    #         gains = list(set([ chunk['gain'] for chunk in wf['chunks'] ]))
+    #         if len(gains) != 1:
+    #             raise ValueError("ERROR: more than 1 gain for a channel")
             
-            minmax[channel] = (np.nanmin(mins), np.nanmax(maxs))
-        return minmax
+    #         minmax[channel] = (np.fmin.reduce(mins), np.fmax.reduce(maxs), gains[0])
+    #     return minmax
         
         
     def write_waveforms(self, path, waveforms):
@@ -483,12 +512,12 @@ class BaseDICOMFormat(BaseFormat):
             subchunks1 = self.split_chunks_temporal_fixed(channel_table, duration_sec = self.chunkSize)
             # print("FIXED", len(subchunks1))
             # self._pretty_print(subchunks1)
-        else:
-            subchunks1 = self.split_chunks_temporal_merged(channel_table)
-            # print("merged", len(subchunks1))
-            # self._pretty_print(subchunks1)
+        # else:
+        #     subchunks1 = self.split_chunks_temporal_merged(channel_table)
+        #     # print("merged", len(subchunks1))
+        #     # self._pretty_print(subchunks1)
     
-        minmax = self._get_waveform_channel_minmax(waveforms)    
+        # minmax = self._get_waveform_channel_minmax(waveforms)    
         #========== now write out =============
 
         # count channels belonging to respiratory data this is needed for the iod
@@ -517,7 +546,11 @@ class BaseDICOMFormat(BaseFormat):
             dicom = self.writer.set_study_info(dicom, studyUID = studyInstanceUID, studyDate = datetime.now())
             dicom = self.writer.set_series_info(dicom, iod, seriesUID=seriesInstanceUID)
             dicom = self.writer.set_waveform_acquisition_info(dicom, instanceNumber = file_id)
-            dicom = self.writer.add_waveform_chunks_multiplexed(dicom, iod, chunk_info, waveforms, minmax)
+            dicom = self.writer.add_waveform_chunks_multiplexed(dicom, iod, chunk_info, waveforms)
+            
+            if dicom is None:
+                # no wave sequence written.  skip
+                continue
             
             # Save DICOM file.  write_like_original is required
             # these the initial path when added - it points to a temp file.
@@ -614,15 +647,14 @@ class BaseDICOMFormat(BaseFormat):
                 samples = [int(x) for x in str.split(item[0x0099, 0x1012].value, sep = ',')]
                 stimes = [float(x) for x in str.split(item[0x0099, 0x1001].value, sep = ',')]
                 etimes = [x + float(y) / z for x, y, z in zip(stimes, samples, freqs)]
-
+                
                 channels = str.split(item[0x0099, 0x1021].value, sep = ',')
                 canonical_channels = [x.upper() for x in channels]
                 group_ids = [ int(x) for x in str.split(item[0x0099, 0x1022].value, sep = ',')]
                 chan_ids = [int(x) for x in str.split(item[0x0099, 0x1023].value, sep = ',')]
 
                 # get group ids and set of channels for all available channels.
-                for (i, chan) in enumerate(channels):
-                    group_id = group_ids[i]
+                for (chan, group_id, chan_id) in zip(channels, group_ids, chan_ids):
                     stime = stimes[group_id]
                     etime = etimes[group_id]
 
@@ -641,7 +673,7 @@ class BaseDICOMFormat(BaseFormat):
 
                     # original channel name
                     channel_info = {'channel': chan,
-                                    'channel_idx': chan_ids[i],
+                                    'channel_idx': chan_id,
                                     'freq': freqs[group_id],
                                     'number_samples': samples[group_id],
                                     'start_time': stime}
@@ -755,12 +787,13 @@ class BaseDICOMFormat(BaseFormat):
 
                         # init the output if not previously allocated
                         if requested_channel_name not in output.keys():
-                            output[requested_channel_name] = np.full(shape = max_len, fill_value = np.nan, dtype=np.float64)
+                            output[requested_channel_name] = np.full(shape = max_len, fill_value = np.nan, dtype=np.float32)
 
                         # copy the data to the output
                         # print("copy ", arrs[group_idx].shape, " to ", output[channel].shape, 
                         #       " from ", target_start, " to ", target_end)
-                        output[requested_channel_name][target_start:target_end] = arrs[group_idx][channel_idx, 0:nsamps]
+                        new_vals = arrs[group_idx][channel_idx, 0:nsamps]
+                        output[requested_channel_name][target_start:target_end] = np.where(np.isfinite(new_vals), new_vals, output[requested_channel_name][target_start:target_end])
 
         t2 = time.time()
         d3 = t2 - t1
@@ -812,19 +845,19 @@ class DICOM16BitsChunked(DICOM16Bits):
     chunkSize = 3600.0
 
 
-class DICOMHighBitsMerged(DICOMHighBits):
-    # waveform lead names to dicom IOD mapping.   Incomplete.
-    # avoiding 12 lead ECG because of the limit in number of samples.
+# class DICOMHighBitsMerged(DICOMHighBits):
+#     # waveform lead names to dicom IOD mapping.   Incomplete.
+#     # avoiding 12 lead ECG because of the limit in number of samples.
 
-    chunkSize = -1
-
-
-class DICOMLowBitsMerged(DICOMLowBits):
-
-    chunkSize = -1
+#     chunkSize = -1
 
 
-class DICOM16BitsMerged(DICOM16Bits):
+# class DICOMLowBitsMerged(DICOMLowBits):
 
-    chunkSize = -1
+#     chunkSize = -1
+
+
+# class DICOM16BitsMerged(DICOM16Bits):
+
+#     chunkSize = -1
 

--- a/waveform_benchmark/formats/dicom.py
+++ b/waveform_benchmark/formats/dicom.py
@@ -424,21 +424,21 @@ class BaseDICOMFormat(BaseFormat):
 
         return out
 
-    def make_iod(self, iod_name: str, hifi: bool, num_channels: int = 1):
+    def make_iod(self, iod_name: str, bits: int, num_channels: int = 1):
         if iod_name == "GeneralECGWaveform":
-            return dcm_writer.GeneralECGWaveform(hifi=hifi)
+            return dcm_writer.GeneralECGWaveform(bits=bits)
         elif iod_name == "AmbulatoryECGWaveform":
-            return dcm_writer.AmbulatoryECGWaveform(hifi=hifi)
+            return dcm_writer.AmbulatoryECGWaveform(bits=bits)
         elif iod_name == "SleepEEGWaveform":
-            return dcm_writer.SleepEEGWaveform(hifi=hifi)
+            return dcm_writer.SleepEEGWaveform(bits=bits)
         elif iod_name == "ElectromyogramWaveform":
-            return dcm_writer.ElectromyogramWaveform(hifi=hifi)
+            return dcm_writer.ElectromyogramWaveform(bits=bits)
         elif iod_name == "ArterialPulseWaveform":
-            return dcm_writer.ArterialPulseWaveform(hifi=hifi)
+            return dcm_writer.ArterialPulseWaveform(bits=bits)
         elif iod_name == "RespiratoryWaveform":
-            return dcm_writer.RespiratoryWaveform(hifi=hifi, num_channels=num_channels)
+            return dcm_writer.RespiratoryWaveform(bits=bits, num_channels=num_channels)
         elif iod_name == "HemodynamicWaveform":
-            return dcm_writer.HemodynamicWaveform(hifi=hifi)
+            return dcm_writer.HemodynamicWaveform(bits=bits)
         else:
             raise ValueError("Unknown IOD")
 
@@ -506,7 +506,7 @@ class BaseDICOMFormat(BaseFormat):
             # print("writing ", iod_name, ", ", file_id)
 
             # create and iod instance
-            iod = self.make_iod(iod_name, hifi=self.hifi, num_channels = count_per_iod[iod_name])
+            iod = self.make_iod(iod_name, bits=self.bits, num_channels = count_per_iod[iod_name])
    
             # each multiplex group can have its own frequency
             # but if there are different frequencies for channels in a multiplex group, we need to split.
@@ -780,28 +780,36 @@ class DICOMHighBits(BaseDICOMFormat):
 
     writer = dcm_writer.DICOMWaveformWriter()
     chunkSize = None # adaptive
-    hifi = True
+    bits = 64 # max possible bits
 
 
 class DICOMLowBits(BaseDICOMFormat):
 
     writer = dcm_writer.DICOMWaveformWriter()
     chunkSize = None  # adaptive
-    hifi = False
+    bits = 0  # min possible bits
 
+class DICOM16Bits(BaseDICOMFormat):
+
+    writer = dcm_writer.DICOMWaveformWriter()
+    chunkSize = None  # adaptive
+    bits = 16
 
 class DICOMHighBitsChunked(DICOMHighBits):
     # waveform lead names to dicom IOD mapping.   Incomplete.
     # avoiding 12 lead ECG because of the limit in number of samples.
 
     chunkSize = 3600.0  # chunk as 1 hr.
-    hifi = True
 
 
 class DICOMLowBitsChunked(DICOMLowBits):
 
     chunkSize = 3600.0
-    hifi = False
+
+
+class DICOM16BitsChunked(DICOM16Bits):
+
+    chunkSize = 3600.0
 
 
 class DICOMHighBitsMerged(DICOMHighBits):
@@ -809,10 +817,14 @@ class DICOMHighBitsMerged(DICOMHighBits):
     # avoiding 12 lead ECG because of the limit in number of samples.
 
     chunkSize = -1
-    hifi = True
 
 
 class DICOMLowBitsMerged(DICOMLowBits):
 
     chunkSize = -1
-    hifi = False
+
+
+class DICOM16BitsMerged(DICOM16Bits):
+
+    chunkSize = -1
+


### PR DESCRIPTION
Previous implementation stored gain * measurements directly, which for some datasets (e.g. Charis8 and Charis9) and some channels (e.g. ABP, ICP) can overflow the value type (e.g. int16).

This pull request changes the encoding to scale the value range to that of the value type. limited testing passed.   It has yet to be tested against Charis8 and Charis9).