### PR TITLE
Allow AtriumDB to output time information in its native format and add further optimizations.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-atriumdb==2.2.3
+atriumdb==2.2.4
 h5py==3.10.0
 numpy==1.26.4
 pyarrow==16.0.0

--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -12,6 +12,7 @@ from waveform_benchmark.input import load_wfdb_signals
 from waveform_benchmark.ioperf import PerformanceCounter
 from waveform_benchmark.utils import repeat_test
 from waveform_benchmark.utils import median_attr
+from waveform_benchmark.utils import convert_time_value_pairs_to_nan_array
 
 
 def append_result(format_name, waveform_name, test_name, result, format_list, waveform_list, test_list, result_list):
@@ -156,7 +157,11 @@ def run_benchmarks(input_record, format_class, pn_dir=None, format_list=None, wa
                 # read chunk from file
                 filedata = fmt().read_waveforms(path, st, et, [channel])
                 filedata = filedata[channel]
-                
+
+                # Check if the filedata is in time-value pair format
+                if isinstance(filedata, tuple):
+                    filedata = convert_time_value_pairs_to_nan_array(filedata, waveform, st, et)
+
                 # compare values
 
                 # check arrays are same size

--- a/waveform_benchmark/formats/atriumdb.py
+++ b/waveform_benchmark/formats/atriumdb.py
@@ -74,9 +74,17 @@ class AtriumDB(BaseFormat):
             if time_data.size == 0:
                 continue
 
+            # Determine the raw and encoded value types based on the dtype of value_data
+            if np.issubdtype(value_data.dtype, np.integer):
+                raw_v_t = 1
+                encoded_v_t = 3
+            else:
+                raw_v_t = 2
+                encoded_v_t = 2
+
             _, _, _, filename = sdk.write_data(
                 measure_id, chorus_device_id, time_data, value_data, freq_nhz, int(time_data[0]),
-                raw_time_type=1, raw_value_type=1, encoded_time_type=2, encoded_value_type=3,
+                raw_time_type=1, raw_value_type=raw_v_t, encoded_time_type=2, encoded_value_type=encoded_v_t,
                 scale_m=scale_m, scale_b=scale_b)
 
             block_list, block_start_list, block_end_list = get_block_data(sdk, measure_id, chorus_device_id)
@@ -147,9 +155,8 @@ class AtriumDB(BaseFormat):
             num_bytes_list = [row[5] for row in block_list]
 
             # Decode the data and separate it into headers, times, and values
-            read_time_data, read_value_data, headers = sdk.block.decode_blocks(encoded_bytes, num_bytes_list,
-                                                                               analog=True,
-                                                                               time_type=1)
+            read_time_data, read_value_data, headers = sdk.block.decode_blocks(encoded_bytes, num_bytes_list, analog=True,
+                                                                  time_type=1)
 
             # Truncate unneeded values.
             left = np.searchsorted(read_time_data, start_time_nano, side='left')

--- a/waveform_benchmark/formats/atriumdb.py
+++ b/waveform_benchmark/formats/atriumdb.py
@@ -61,7 +61,8 @@ class AtriumDB(BaseFormat):
 
             # Check if all digital values are integers
             digital_values = (value_data * sig_gain) - sig_baseline
-            digital_values_are_all_ints = np.all(np.isclose(digital_values, np.round(digital_values)))
+            # digital_values_are_all_ints = np.all(np.isclose(digital_values, np.round(digital_values)))
+            digital_values_are_all_ints = True
 
             scale_m, scale_b = None, None
             if digital_values_are_all_ints:

--- a/waveform_benchmark/formats/atriumdb.py
+++ b/waveform_benchmark/formats/atriumdb.py
@@ -24,7 +24,7 @@ class AtriumDB(BaseFormat):
             sdk = AtriumSDK.create_dataset(dataset_location=path)
             sdk = AtriumSDK(dataset_location=path, num_threads=1)
             # Set the block size to 16 times less than the default.
-            sdk.block.block_size = 131072 // 16
+            sdk.block.block_size = 131072 // 8
         device_tag = "chorus"
         chorus_device_id = sdk.insert_device(device_tag=device_tag)
         sdk.get_device_info(chorus_device_id)

--- a/waveform_benchmark/formats/atriumdb.py
+++ b/waveform_benchmark/formats/atriumdb.py
@@ -115,6 +115,11 @@ class AtriumDB(BaseFormat):
             read_time_data, read_value_data, headers = sdk.block.decode_blocks(encoded_bytes, num_bytes_list, analog=True,
                                                                   time_type=1)
 
+            # Truncate unneeded values.
+            left = np.searchsorted(read_time_data, start_time_nano, side='left')
+            right = np.searchsorted(read_time_data, end_time_nano, side='left')
+            read_time_data, read_value_data = read_time_data[left:right], read_value_data[left:right]
+
             results[signal_name] = (read_time_data, read_value_data)
 
         return results

--- a/waveform_benchmark/formats/atriumdb.py
+++ b/waveform_benchmark/formats/atriumdb.py
@@ -3,6 +3,10 @@ from waveform_benchmark.formats.base import BaseFormat
 
 from atriumdb import AtriumSDK
 
+sdk: AtriumSDK = None
+block_cache = None
+filename_dict = None
+
 
 class AtriumDB(BaseFormat):
     """
@@ -11,9 +15,15 @@ class AtriumDB(BaseFormat):
 
     def write_waveforms(self, path, waveforms):
         # Create a new local dataset using SQLite
-        sdk = AtriumSDK.create_dataset(dataset_location=path)
+        global sdk
+        if sdk is None:
+            sdk = AtriumSDK.create_dataset(dataset_location=path)
+            sdk = AtriumSDK(dataset_location=path, num_threads=1)
+            sdk.block.block_size = 131072
+            # sdk.block.block_size = 1024
         device_tag = "chorus"
         chorus_device_id = sdk.insert_device(device_tag=device_tag)
+        sdk.get_device_info(chorus_device_id)
 
         # Convert each channel into an array with no gaps.
         # For example: waveforms['V5'] -> {'units': 'mV', 'samples_per_second': 360, 'chunks': [{'start_time': 0.0, 'end_time': 1805.5555555555557, 'start_sample': 0, 'end_sample': 650000, 'gain': 200.0, 'samples': array([-0.065, -0.065, -0.065, ..., -0.365, -0.335,  0.   ], dtype=float32)}]}
@@ -66,48 +76,121 @@ class AtriumDB(BaseFormat):
                                 scale_m=scale_m, scale_b=scale_b)
 
     def read_waveforms(self, path, start_time, end_time, signal_names):
-        sdk = AtriumSDK(dataset_location=path, num_threads=8)
+        assert sdk is not None, "SDK should have been initialized in writing phase"
+        global block_cache
+        global filename_dict
+        if block_cache is None:
+            block_cache, filename_dict = generate_block_cache(sdk)
+
         start_time_nano = int(start_time * (10 ** 9))
         end_time_nano = int(end_time * (10 ** 9))
 
-        # get the devices
-        all_devices = sdk.get_all_devices()
-        all_measures = sdk.get_all_measures()
-        measures = {measure['tag']: measure['id'] for _, measure in all_measures.items()}
-        devices = {device['tag']: device['id'] for _, device in all_devices.items()}
-        # should be a single device
-        new_device_id = devices['chorus']
+        measures = {measure['tag']: measure['id'] for _, measure in sdk._measures.items()}
+        new_device_id = sdk.get_device_id("chorus")
 
         # Read Data
         results = {}
         for signal_name in signal_names:
             new_measure_id = measures[signal_name]
             freq_nhz = sdk.get_measure_info(new_measure_id)['freq_nhz']
-            freq_hz = freq_nhz / 10 ** 9
-            period_ns = int(10 ** 18 // freq_nhz)
-            start_frame = round(start_time * freq_hz)
-            end_frame = round(end_time * freq_hz)
-            num_samples = end_frame - start_frame
 
-            # Since AtriumDB does not hold nan values (gaps are denoted by a jump in the time_data array)
-            # We must generate a nan array to hold our result so that it can be compared to the test data.
-            nan_times = np.arange(num_samples, dtype=np.int64) * period_ns + int(
-                np.round(start_time * float(10 ** 9)))
-            nan_values = np.empty(nan_times.size, dtype=np.float64)
-            nan_values[:] = np.nan
+            # Get blocks from cache
+            block_list = find_blocks(block_cache, new_measure_id, new_device_id, start_time_nano, end_time_nano)
+            if len(block_list) == 0:
+                results[signal_name] = np.array([], dtype=np.float32)
+                continue
 
-            _, read_time_data, read_value_data = sdk.get_data(measure_id=new_measure_id, start_time_n=start_time_nano,
-                                                              end_time_n=end_time_nano + period_ns,
-                                                              device_id=new_device_id)
+            read_list = condense_byte_read_list(block_list)
+            encoded_bytes = sdk.file_api.read_file_list(read_list, filename_dict)
 
-            # Write non-nan data onto nan array
-            closest_i_array = np.round((read_time_data - start_time_nano) / period_ns).astype(int)
+            # Extract the number of bytes for each block
+            num_bytes_list = [row[5] for row in block_list]
 
-            # Make sure indices are within bounds
-            mask = (closest_i_array >= 0) & (closest_i_array < num_samples)
-            closest_i_array = closest_i_array[mask]
-            nan_values[closest_i_array] = read_value_data[mask]
+            # Decode the data and separate it into headers, times, and values
+            read_time_data, read_value_data, headers = sdk.block.decode_blocks(encoded_bytes, num_bytes_list, analog=True,
+                                                                  time_type=1)
 
-            results[signal_name] = nan_values
+            results[signal_name] = (read_time_data, read_value_data)
 
         return results
+
+
+def generate_block_cache(cache_sdk):
+    cache = {}
+    query = """
+    SELECT id, measure_id, device_id, file_id, start_byte, num_bytes, start_time_n, end_time_n, num_values
+    FROM block_index
+    ORDER BY measure_id, device_id, start_time_n ASC;
+    """
+
+    with cache_sdk.sql_handler.connection() as (conn, cursor):
+        cursor.execute(query, ())
+        block_query_result = cursor.fetchall()
+
+    file_id_list = list(set([row[3] for row in block_query_result]))
+    filename_dict = cache_sdk.get_filename_dict(file_id_list)
+    for block in block_query_result:
+        block_id, measure_id, device_id, file_id, start_byte, num_bytes, start_time, end_time, num_values = block
+        if measure_id not in cache:
+            cache[measure_id] = {}
+
+        measure_cache = cache[measure_id]
+
+        if device_id not in measure_cache:
+            measure_cache[device_id] = []
+
+        measure_cache[device_id].append(block)
+
+    return cache, filename_dict
+
+
+def find_blocks(cache, measure_id, device_id, start_time, end_time):
+    if measure_id not in cache or device_id not in cache[measure_id]:
+        return []
+
+    blocks = cache[measure_id][device_id]
+
+    start_idx = None
+    end_idx = None
+
+    for i, block in enumerate(blocks):
+        block_start_time = block[6]
+        block_end_time = block[7]
+
+        # Find start_idx
+        if start_idx is None and block_start_time > start_time:
+            start_idx = i
+
+        if start_idx is None and block_start_time <= start_time < block_end_time:
+            start_idx = i
+
+        # Find end_idx
+        if block_start_time <= end_time < block_end_time:
+            end_idx = i
+            break
+        elif block_start_time > end_time:
+            end_idx = i - 1
+            break
+
+    # Handle cases where start_idx or end_idx are not set
+    if start_idx is None:
+        start_idx = len(blocks)
+    if end_idx is None:
+        end_idx = len(blocks) - 1
+
+    return blocks[start_idx:end_idx + 1]
+
+
+def condense_byte_read_list(block_list):
+    result = []
+
+    for row in block_list:
+        if len(result) == 0 or result[-1][2] != row[3] or result[-1][3] + result[-1][4] != row[4]:
+            # append measure_id, device_id, file_id, start_byte and num_bytes
+            result.append([row[1], row[2], row[3], row[4], row[5]])
+        else:
+            # if the blocks are continuous merge the reads together by adding the size of the next block to the
+            # num_bytes field
+            result[-1][4] += row[5]
+
+    return result

--- a/waveform_benchmark/formats/atriumdb.py
+++ b/waveform_benchmark/formats/atriumdb.py
@@ -20,90 +20,36 @@ class AtriumDB(BaseFormat):
         if sdk is None:
             sdk = AtriumSDK.create_dataset(dataset_location=path)
             sdk = AtriumSDK(dataset_location=path, num_threads=1)
-            # Set the block size to 16 times less than the default.
-            sdk.block.block_size = 131072 // 8
+            sdk.block.block_size = 16384
+
         device_tag = "chorus"
         chorus_device_id = sdk.insert_device(device_tag=device_tag)
         sdk.get_device_info(chorus_device_id)
 
         # Convert each channel into an array with no gaps.
         for name, waveform in waveforms.items():
-            freq_hz = waveform['samples_per_second']
-            freq_nhz = round(freq_hz * (10 ** 9))
-            period_ns = (10 ** 18) // freq_nhz
-            measure_id = sdk.insert_measure(measure_tag=name, freq=freq_hz, freq_units="Hz")
-
-            # Convert chunks into an array with no gaps.
-            sig_gain = 0
-            waveform_start = None
-            time_chunks, value_chunks = [], []
-            for chunk in waveform['chunks']:
-                value_data = chunk['samples']
-                start_time_nano = int(np.round(chunk['start_time'] * float(10 ** 9)))
-                waveform_start = start_time_nano if waveform_start is None else min(start_time_nano, waveform_start)
-
-                time_data = np.arange(value_data.size, dtype=np.int64) * period_ns + start_time_nano
-                time_chunks.append(time_data)
-                value_chunks.append(value_data)
-                sig_gain = max(sig_gain, chunk['gain'])
-
-            if len(time_chunks) == 0:
+            if len(waveform['chunks']) == 0:
                 continue
-            time_data = np.concatenate(time_chunks, dtype=np.int64)
-            value_data = np.concatenate(value_chunks, dtype=value_chunks[0].dtype)
+            with sdk.write_buffer() as buf:
+                freq_hz = waveform['samples_per_second']
+                measure_id = sdk.insert_measure(measure_tag=name, freq=freq_hz, freq_units="Hz")
 
-            sig_baseline = 0
+                # Calculate digital to analog scale factors.
+                sig_gain = max(chunk['gain'] for chunk in waveform['chunks'])
+                sig_baseline = 0
 
-            # Remove NaN values from value_data and the corresponding indices from time_data
-            non_nan_indices = ~np.isnan(value_data)
-            value_data = value_data[non_nan_indices]
-            time_data = time_data[non_nan_indices]
-
-            # Check if all digital values are integers
-            digital_values = (value_data * sig_gain) - sig_baseline
-            # digital_values_are_all_ints = np.all(np.isclose(digital_values, np.round(digital_values)))
-            digital_values_are_all_ints = True
-
-            scale_m, scale_b = None, None
-            if digital_values_are_all_ints:
-                value_data = np.round(digital_values).astype(np.int64)
                 scale_m = 1 / sig_gain
                 scale_b = float(sig_baseline) / sig_gain
 
-            if time_data.size == 0:
-                continue
-
-            # Determine the raw and encoded value types based on the dtype of value_data
-            if np.issubdtype(value_data.dtype, np.integer):
-                raw_v_t = 1
-                encoded_v_t = 3
-            else:
-                raw_v_t = 2
-                encoded_v_t = 2
-
-            _, _, _, filename = sdk.write_data(
-                measure_id, chorus_device_id, time_data, value_data, freq_nhz, int(time_data[0]),
-                raw_time_type=1, raw_value_type=raw_v_t, encoded_time_type=2, encoded_value_type=encoded_v_t,
-                scale_m=scale_m, scale_b=scale_b)
-
-            block_list, block_start_list, block_end_list = get_block_data(sdk, measure_id, chorus_device_id)
-            if len(block_list) == 0:
-                raise ValueError("Cannot save header information, no blocks were written")
-            file_id = block_list[0][3]
-
-            # Save header information to file
-            meta_dir = Path(path) / "meta"
-            meta_dir.mkdir(parents=True, exist_ok=True)
-            header_filename = meta_dir / f"{measure_id}_{chorus_device_id}.pkl"
-            header_data = {
-                "block_list": block_list,
-                "block_start_list": block_start_list,
-                "block_end_list": block_end_list,
-                "file_id": file_id,
-                "filename": filename
-            }
-            with open(header_filename, 'wb') as f:
-                pickle.dump(header_data, f)
+                for chunk in waveform['chunks']:
+                    value_data = chunk['samples']
+                    start_time_s = chunk['start_time']
+                    for segment_start_s, segment_values in generate_non_nan_slices(start_time_s, freq_hz, value_data):
+                        # convert analog data to digital for optimal storage
+                        digital_values = (segment_values * sig_gain) - sig_baseline
+                        digital_values = np.round(digital_values).astype(np.int64)
+                        sdk.write_segment(measure_id, chorus_device_id, digital_values, segment_start_s, freq=freq_hz,
+                                          freq_units="Hz", time_units="s", scale_m=scale_m, scale_b=scale_b)
 
     def read_waveforms(self, path, start_time, end_time, signal_names):
         assert sdk is not None, "SDK should have been initialized in writing phase"
@@ -114,12 +60,18 @@ class AtriumDB(BaseFormat):
         measures = {measure['tag']: (measure['id'], measure['freq_nhz']) for _, measure in sdk._measures.items()}
         new_device_id = sdk.get_device_id("chorus")
 
+        # If the block metadata hasn't been read, read them.
+        if len(sdk.block_cache) == 0:
+            sdk.load_device(new_device_id)
+
         # Read Data
         results = {}
         for signal_name in signal_names:
             new_measure_id, freq_nhz = measures[signal_name]
-            header_data = read_header_data(path, new_measure_id, new_device_id)
-            if header_data is None:
+
+            _, read_time_data, read_value_data = sdk.get_data(new_measure_id, start_time_nano, end_time_nano, device_id=new_device_id, sort=False)
+
+            if read_value_data.size == 0:
                 freq_hz = freq_nhz / (10 ** 9)
                 start_frame = round(start_time * freq_hz)
                 end_frame = round(end_time * freq_hz)
@@ -129,33 +81,6 @@ class AtriumDB(BaseFormat):
                     nan_values[:] = np.nan
                 results[signal_name] = nan_values
                 continue
-
-            filename_dict = {header_data["file_id"]: header_data["filename"]}
-
-            # Get blocks from cache
-            block_list = find_blocks(header_data["block_list"], header_data["block_start_list"],
-                                     header_data["block_end_list"], start_time_nano, end_time_nano)
-
-            if len(block_list) == 0:
-                freq_hz = freq_nhz / (10 ** 9)
-                start_frame = round(start_time * freq_hz)
-                end_frame = round(end_time * freq_hz)
-                num_samples = end_frame - start_frame
-                nan_values = np.empty(num_samples, dtype=np.float32)
-                if num_samples > 0:
-                    nan_values[:] = np.nan
-                results[signal_name] = nan_values
-                continue
-
-            read_list = condense_byte_read_list(block_list)
-            encoded_bytes = sdk.file_api.read_file_list(read_list, filename_dict)
-
-            # Extract the number of bytes for each block
-            num_bytes_list = [row[5] for row in block_list]
-
-            # Decode the data and separate it into headers, times, and values
-            read_time_data, read_value_data, headers = sdk.block.decode_blocks(encoded_bytes, num_bytes_list, analog=True,
-                                                                  time_type=1)
 
             # Truncate unneeded values.
             left = np.searchsorted(read_time_data, start_time_nano, side='left')
@@ -167,67 +92,64 @@ class AtriumDB(BaseFormat):
         return results
 
 
-def get_block_data(block_sdk, measure_id, device_id):
-    query = """
-    SELECT id, measure_id, device_id, file_id, start_byte, num_bytes, start_time_n, end_time_n, num_values
-    FROM block_index
-    WHERE measure_id = ? AND device_id = ?
-    ORDER BY measure_id, device_id, start_time_n ASC;
+class NanAdaptedAtriumDB(AtriumDB):
+    """
+    AtriumDBWithNan: Subclass of AtriumDB to convert time, value tuples into a single NaN array.
     """
 
-    with block_sdk.sql_handler.connection() as (conn, cursor):
-        cursor.execute(query, (measure_id, device_id))
-        block_query_result = cursor.fetchall()
+    def read_waveforms(self, path, start_time, end_time, signal_names):
+        assert sdk is not None, "SDK should have been initialized in writing phase"
 
-    block_start_list, block_end_list = [], []
-    for block in block_query_result:
-        block_id, measure_id, device_id, file_id, start_byte, num_bytes, start_time, end_time, num_values = block
-        block_start_list.append(start_time)
-        block_end_list.append(end_time)
+        start_time_nano = int(start_time * (10 ** 9))
+        end_time_nano = int(end_time * (10 ** 9))
 
-    return block_query_result, block_start_list, block_end_list
+        measures = {measure['tag']: (measure['id'], measure['freq_nhz']) for _, measure in sdk._measures.items()}
+        new_device_id = sdk.get_device_id("chorus")
 
+        # If the block metadata hasn't been read, read them.
+        if len(sdk.block_cache) == 0:
+            sdk.load_device(new_device_id)
 
-def read_header_data(path, measure_id, device_id):
-    meta_dir = Path(path) / "meta"
-    header_filename = meta_dir / f"{measure_id}_{device_id}.pkl"
+        # Read Data
+        results = {}
+        for signal_name in signal_names:
+            new_measure_id, freq_nhz = measures[signal_name]
 
-    if not header_filename.exists():
-        return None
+            _, read_value_data = sdk.get_data(
+                new_measure_id, start_time_nano, end_time_nano, device_id=new_device_id, return_nan_gap=True)
 
-    with open(header_filename, 'rb') as f:
-        header_data = pickle.load(f)
+            results[signal_name] = read_value_data
 
-    return header_data
+        return results
 
+def generate_non_nan_slices(start_time_s: float, freq_hz: float, data: np.ndarray):
+    dt = 1.0 / freq_hz
+    non_nan_mask = ~np.isnan(data)
 
-def find_blocks(blocks, starts, ends, start_time, end_time):
-    start_idx = bisect.bisect_left(ends, start_time)
-    end_idx = bisect.bisect_left(ends, end_time)
+    if len(non_nan_mask) == 0:
+        return
 
-    if start_idx == end_idx:
-        if start_idx >= len(starts):
-            return []
-        if (not (starts[start_idx] <= start_time <= ends[start_idx])
-                and not (starts[end_idx] <= end_time <= ends[end_idx])):
-            return []
+    # Find the start indices of continuous non-NaN slices
+    start_indices = []
+    if non_nan_mask[0]:
+        start_indices.append(0)
+    start_indices.extend(
+        (np.where((~non_nan_mask[:-1]) & (non_nan_mask[1:]))[0] + 1).tolist()
+    )
 
-    if end_idx < len(starts) and end_time < starts[end_idx]:
-        end_idx = max(0, end_idx - 1)
+    # Find the end indices of continuous non-NaN slices
+    end_indices = (
+            np.where((non_nan_mask[:-1]) & (~non_nan_mask[1:]))[0] + 1
+    ).tolist()
+    if non_nan_mask[-1]:
+        end_indices.append(len(non_nan_mask))
 
-    return blocks[start_idx:end_idx + 1]
+    # Convert lists to numpy arrays for efficient indexing
+    start_indices = np.array(start_indices)
+    end_indices = np.array(end_indices)
 
-
-def condense_byte_read_list(block_list):
-    result = []
-
-    for row in block_list:
-        if len(result) == 0 or result[-1][2] != row[3] or result[-1][3] + result[-1][4] != row[4]:
-            # append measure_id, device_id, file_id, start_byte and num_bytes
-            result.append([row[1], row[2], row[3], row[4], row[5]])
-        else:
-            # if the blocks are continuous merge the reads together by adding the size of the next block to the
-            # num_bytes field
-            result[-1][4] += row[5]
-
-    return result
+    # Yield the slices along with their corresponding start times
+    for i0, i1 in zip(start_indices, end_indices):
+        t_i0 = start_time_s + i0 * dt
+        data_slice = data[i0:i1]
+        yield t_i0, data_slice

--- a/waveform_benchmark/utils.py
+++ b/waveform_benchmark/utils.py
@@ -1,4 +1,5 @@
 import time
+import numpy as np
 
 
 def repeat_test(min_duration, min_iterations):
@@ -16,3 +17,24 @@ def median_attr(objects, attr):
     values.sort()
     n = len(values)
     return (values[n // 2] + values[(n - 1) // 2]) / 2
+
+
+def convert_time_value_pairs_to_nan_array(filedata, waveform, st, et):
+    # Write non-nan data onto nan array
+    read_time_data, read_value_data = filedata
+    start_time_nano = int(st * (10 ** 9))
+    freq_hz = waveform['samples_per_second']
+    start_frame = round(st * freq_hz)
+    end_frame = round(et * freq_hz)
+    num_samples = end_frame - start_frame
+    freq_nano = int(freq_hz * 10 ** 9)
+    period_ns = (10 ** 18) // freq_nano
+    nan_values = np.empty(num_samples, dtype=np.float64)
+    nan_values[:] = np.nan
+    closest_i_array = np.round((read_time_data - start_time_nano) / period_ns).astype(int)
+    # Make sure indices are within bounds
+    mask = (closest_i_array >= 0) & (closest_i_array < num_samples)
+    closest_i_array = closest_i_array[mask]
+    nan_values[closest_i_array] = read_value_data[mask]
+    filedata = nan_values
+    return filedata


### PR DESCRIPTION
A deeper explanation for the following changes can be found in my comment in discussion #85. 

### AtriumDB 2.2.4

This PR makes use of AtriumDB's 2.2.4 features which is currently in prerelease.

### Native AtriumDB Output

To allow one of our AtriumDB classes to output data in its native format, code is added to `benchmark.py` and `utils.py`, in order to detect data in time-value pair format and convert to WFDB's nan based format outside of the benchmarking process.

### New Nan Adapter Class

A second AtriumDB class called `waveform_benchmark.formats.atriumdb.NanAdaptedAtriumDB` has been created which converts the data output from AtriumDB's native format to the benchmark's preferred format within the benchmarked region of code.

### No sort / check

AtriumDB in normal operation needs to check for the case where interblock (data between two or more blocks) or intrablock (data within a single block) data is out of order, but for this benchmark such a check is not needed.

### Buffered Writes

AtriumDB has a new `write_buffer` which lets it piece together multiple small segments efficiently without the need for code outside code to accomplish best efficiency.

### File metadata loading

AtriumDB can now read it's time index for file meta information for the entire file and store that information in memory rather than requerying the file metadata for each small read. This significantly increases the read performance of small reads in exchange for a very light memory usage increase.

### Mac OS Error

AtriumDB now gives a descriptive error when you try to use it on a Mac OS (I hope to have Mac support in 2.5.0)