### PR TITLE
Catch open once read many exception for formats which don't implement required functions

### DIFF
--- a/waveform_benchmark/formats/base.py
+++ b/waveform_benchmark/formats/base.py
@@ -27,16 +27,13 @@ class BaseFormat(abc.ABC):
     
     # kwargs is a dictionary that can be used to pass additional arguments to the format
     # replaces the total_length, block_length, and block_size params which are either test specific or intrinsic to the format.
-    @abc.abstractmethod
     def open_waveforms(self, path: str, signal_names:list, **kwargs):
         raise NotImplementedError
 
-    @abc.abstractmethod
     def read_opened_waveforms(self, opened_files: dict, start_time: float, end_time: float,
                              signal_names: list):
         raise NotImplementedError
 
-    @abc.abstractmethod
     def close_waveforms(self, opened_files: dict):
         raise NotImplementedError
       


### PR DESCRIPTION
This PR catches the `NotImplementedError` exception during the open once read many testing if a format hasn't implemented the required functions. This allows the other tests to run successfully for all formats. 

Apologies for the minor formatting changes, my editor was being boisterous. 