### PR TITLE
Adds lint.yml action to check style of new code with flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 119
+ignore = F401, F403, W503

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,53 @@
+name: Run style checks
+
+on:
+    push:
+      branches:
+        - main
+    pull_request:
+      branches:
+        - main
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+
+      - name: Run code style check on changed files relative to PR base branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git rev-parse --verify ${{ github.event.pull_request.base.sha }}
+          git diff -U0 ${{ github.event.pull_request.base.sha }} HEAD | \
+              flake8 --diff | \
+              perl -ne '
+                print; if (/^([^:]+):(\d+):(\d+):/) {
+                  $path = $1; $line = $2; $col = $3;
+                  open F, $path or die;
+                  print "\n";
+                  while (<F>) {
+                    next if $. < $line - 2;
+                    print " $_";
+                    if ($. == $line) { print " " x $col . "^\n\n"; last; }
+                  }
+                  close F;
+                  $status = 1;
+                }
+                END { exit $status }'
+
+      - name: Run code style check on the entire codebase for push events
+        if: github.event_name == 'push'
+        run: |
+          flake8 .


### PR DESCRIPTION
This pull request adds a style check to the GitHub actions. Thanks to some clever Perl by @bemoody, the checks should run only against code added in pull requests.

Flake8 configuration is set in the .flake8 file. The current configuration is:

- Set Max Line Length to 119 characters.
- Ignore Unused imports (F401): Flake8 won't raise issues if there are imports that are not used in the code.
- Ignore Wildcard imports (F403): Flake8 won't raise issues if you use wildcard imports.
- Ignore Binary operator line breaks (W503): Flake8 won't raise issues if a line break happens before a binary operator.
