### PR TITLE
Fix AtriumDB version in requirements.txt to match desired release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-atriumdb==2.2.4
+atriumdb==2.4.0
 h5py==3.10.0
 numpy==1.26.4
 pyarrow==16.0.0


### PR DESCRIPTION
The current atriumdb version specified in requirements.txt: 2.2.4 doesn't exist and fails when trying to install from PyPi.

This branch corrects the error to specify 2.4.0