### PR TITLE
Prevent error in github action if no benchmarks are run.

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -111,9 +111,13 @@ jobs:
 
       - name: Concatenate results
         run: |
-          cat benchmark_results_*.txt > final_results.txt
-          echo "Benchmark results:"
-          cat final_results.txt
+          if ls benchmark_results_*.txt 1> /dev/null 2>&1; then
+            cat benchmark_results_*.txt > final_results.txt
+            echo "Benchmark results:"
+            cat final_results.txt
+          else
+            echo "No benchmarks were run." > final_results.txt
+          fi
 
       - name: Post results to pull request
         uses: actions/github-script@v7


### PR DESCRIPTION
We currently have a [github action that runs benchmarks](https://github.com/chorus-ai/chorus_waveform/blob/main/.github/workflows/benchmark.yml) when a format is added or edited.

The action errors out when [base formats](https://github.com/chorus-ai/chorus_waveform/blob/main/waveform_benchmark/formats/base.py) are edited because the "Run benchmark tests" step is skipped but the "Concatenate results" step is still looking for `benchmark_results_*.txt` file/s to report. See for example: https://github.com/chorus-ai/chorus_waveform/actions/runs/11615143978/job/32344989477

This pull request should fix the problem, by wrapping the `cat benchmark_results_*.txt` step in an if clause. If the file doesn't exist, we now report "No benchmarks were run.", instead of raising an error.

