### PR TITLE
Remove 'post comment' step from benchmark action

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -119,20 +119,21 @@ jobs:
             echo "No benchmarks were run." > final_results.txt
           fi
 
-      - name: Post results to pull request
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const fs = require('fs');
-            const filePath = 'final_results.txt';
-            if (!fs.existsSync(filePath) || fs.statSync(filePath).size === 0) {
-              console.log("No results to post.");
-              return;
-            }
-            const resultContent = fs.readFileSync(filePath, 'utf8');
-            await github.rest.issues.createComment({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-              body: `Benchmark results:\n\`\`\`\n${resultContent}\n\`\`\``
-            });
+      # Requires private TOKEN to be added to run on PRS from external repos
+      # - name: Post results to pull request
+      #   uses: actions/github-script@v7
+      #   with:
+      #     script: |
+      #       const fs = require('fs');
+      #       const filePath = 'final_results.txt';
+      #       if (!fs.existsSync(filePath) || fs.statSync(filePath).size === 0) {
+      #         console.log("No results to post.");
+      #         return;
+      #       }
+      #       const resultContent = fs.readFileSync(filePath, 'utf8');
+      #       await github.rest.issues.createComment({
+      #         owner: context.repo.owner,
+      #         repo: context.repo.repo,
+      #         issue_number: context.issue.number,
+      #         body: `Benchmark results:\n\`\`\`\n${resultContent}\n\`\`\``
+      #       });


### PR DESCRIPTION
When a pull request comes from a forked repository, the "Post results to pull request" action in the Benchmark.yml workflow fails (e.g. see: https://github.com/chorus-ai/chorus_waveform/pull/105). 

The issue is that the GITHUB_TOKEN provided by GitHub Actions only has read permissions. This can be fixed by adding a custom token, but it is quicker and easier to remove the post results step, which is what I am doing here!

The benchmark results should still be posted in the output of the github action, so it's not a big loss.



