### PR TITLE
Fix benchmarking error when NaNs are in unexpected locations

### DIFF
--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -153,8 +153,8 @@ def compute_snr(reference_signal, output_signal):
     output_signal = np.asarray(output_signal)
 
     # Check that the signals have the same dimensions and all finite values.
-    assert (np.array_equal(np.shape(reference_signal), np.shape(output_signal)))
-    assert (np.all(np.isfinite(reference_signal)) and np.all(np.isfinite(output_signal)))
+    np.array_equal(np.shape(reference_signal), np.shape(output_signal))
+    np.all(np.isfinite(reference_signal)) and np.all(np.isfinite(output_signal))
 
     # Compute the noise in the signal.
     noise_signal = output_signal - reference_signal
@@ -422,7 +422,7 @@ def run_benchmarks(input_record, format_class, pn_dir=None, format_list=None, wa
                     # read chunk from file
                     filedata = fmt().open_read_close_waveforms(path, st, et, [channel])
                     filedata = filedata[channel]
-
+                     
                     # compare values
 
                     # check arrays are same size

--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -152,10 +152,6 @@ def compute_snr(reference_signal, output_signal):
     reference_signal = np.asarray(reference_signal)
     output_signal = np.asarray(output_signal)
 
-    # Check that the signals have the same dimensions and all finite values.
-    np.array_equal(np.shape(reference_signal), np.shape(output_signal))
-    np.all(np.isfinite(reference_signal)) and np.all(np.isfinite(output_signal))
-
     # Compute the noise in the signal.
     noise_signal = output_signal - reference_signal
 

--- a/waveform_benchmark/benchmark.py
+++ b/waveform_benchmark/benchmark.py
@@ -151,6 +151,9 @@ def compute_snr(reference_signal, output_signal):
     # Convert the data to NumPy arrays as needed.
     reference_signal = np.asarray(reference_signal)
     output_signal = np.asarray(output_signal)
+    
+    # Check that the signals have the same dimensions.
+    assert (np.array_equal(np.shape(reference_signal), np.shape(output_signal)))
 
     # Compute the noise in the signal.
     noise_signal = output_signal - reference_signal
@@ -418,7 +421,7 @@ def run_benchmarks(input_record, format_class, pn_dir=None, format_list=None, wa
                     # read chunk from file
                     filedata = fmt().open_read_close_waveforms(path, st, et, [channel])
                     filedata = filedata[channel]
-                     
+                    
                     # compare values
 
                     # check arrays are same size


### PR DESCRIPTION
As discussed in https://github.com/chorus-ai/chorus_waveform/issues/108 , the Fidelity check in the benchmarking code will error out when the location of NaNs is not exactly as expected. This removes the `assert` statements from `compute_snr`. As suggested by @matthewreyna , this allows the program to continue even when the NaNs are in unexpected locations. 