### PR TITLE
Fix chorus-image-waveform.yml action.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,12 @@
 requires = ["setuptools"]
 build-backend = "setuptools.build_meta"
 
+[tool.setuptools]
+package-dir = {"" = "waveform_benchmark"}
+
+[tool.setuptools.packages]
+find = { where = ["waveform_benchmark"] }
+
 [project]
 name = "chorus_waveform"
 version = "1.0.0"


### PR DESCRIPTION
The chorus-image-waveform.yml is [currently failing](https://github.com/chorus-ai/chorus_waveform/actions/runs/11673332683/job/32503823085) with the following error:

```
#21 [stage-1 11/11] RUN pip install --no-cache-dir --no-deps -e .
#21 0.423 Obtaining file:///app/chorus_waveform
#21 0.425   Installing build dependencies: started
#21 2.199   Installing build dependencies: finished with status 'done'
#21 2.200   Checking if build backend supports build_editable: started
#21 2.319   Checking if build backend supports build_editable: finished with status 'done'
#21 2.320   Getting requirements to build editable: started
#21 2.503   Getting requirements to build editable: finished with status 'error'
#21 2.509   error: subprocess-exited-with-error
#21 2.509   
#21 2.509   × Getting requirements to build editable did not run successfully.
#21 2.509   │ exit code: 1
#21 2.509   ╰─> [14 lines of output]
#21 2.509       error: Multiple top-level packages discovered in a flat-layout: ['UFFormatConverter', 'waveform_benchmark'].
#21 2.509       
#21 2.509       To avoid accidental inclusion of unwanted files or directories,
#21 2.509       setuptools will not proceed with this build.
#21 2.509       
#21 2.509       If you are trying to create a single distribution with multiple packages
#21 2.509       on purpose, you should not rely on automatic discovery.
#21 2.509       Instead, consider the following options:
#21 2.509       
#21 2.509       1. set up custom discovery (`find` directive with `include` or `exclude`)
#21 2.509       2. use a `src-layout`
#21 2.509       3. explicitly set `py_modules` or `packages` with a list of names
#21 2.509       
#21 2.509       To find more information, look for "package discovery" on setuptools docs.
#21 2.509       [end of output]
#21 2.509   
#21 2.509   note: This error originates from a subprocess, and is likely not a problem with pip.
#21 2.510 error: subprocess-exited-with-error
#21 2.510 
#21 2.510 × Getting requirements to build editable did not run successfully.
#21 2.510 │ exit code: 1
#21 2.510 ╰─> See above for output.
#21 2.510 
#21 2.510 note: This error originates from a subprocess, and is likely not a problem with pip.
#21 2.608 
#21 2.608 [notice] A new release of pip is available: 23.2.1 -> 24.3.1
#21 2.608 [notice] To update, run: python3 -m pip install --upgrade pip
#21 ERROR: process "/bin/sh -c pip install --no-cache-dir --no-deps -e ." did not complete successfully: exit code: 1
------
 > [stage-1 11/11] RUN pip install --no-cache-dir --no-deps -e .:
2.510 error: subprocess-exited-with-error
2.510 
2.510 × Getting requirements to build editable did not run successfully.
2.510 │ exit code: 1
2.510 ╰─> See above for output.
2.510 
2.510 note: This error originates from a subprocess, and is likely not a problem with pip.
2.608 
Notice: 2.608 [notice] A new release of pip is available: 23.2.1 -> 24.3.1
Notice: 2.608 [notice] To update, run: python3 -m pip install --upgrade pip
------

 1 warning found (use docker --debug to expand):
 - FromAsCasing: 'as' and 'FROM' keywords' casing do not match (line 1)
Dockerfile:24
--------------------
  22 |                     pytest
  23 |     RUN pip install --no-cache-dir -r requirements.txt
  24 | >>> RUN pip install --no-cache-dir --no-deps -e .
  25 |     
--------------------
ERROR: failed to solve: process "/bin/sh -c pip install --no-cache-dir --no-deps -e ." did not complete successfully: exit code: 1
Error: buildx failed with: ERROR: failed to solve: process "/bin/sh -c pip install --no-cache-dir --no-deps -e ." did not complete successfully: exit code: 1
```

Running pip install locally confirms that the problem is that the package directory is not specified:

```
[tompollard:~/projects/chorus_waveform] [env] main* ± pip install --no-cache-dir --no-deps -e .
Obtaining file:///Users/tompollard/projects/chorus_waveform
  Installing build dependencies ... done
  Checking if build backend supports build_editable ... done
  Getting requirements to build editable ... error
  error: subprocess-exited-with-error
  
  × Getting requirements to build editable did not run successfully.
  │ exit code: 1
  ╰─> [14 lines of output]
      error: Multiple top-level packages discovered in a flat-layout: ['data', 'UFFormatConverter', 'UVAFormatConverter', 'waveform_benchmark'].
      
      To avoid accidental inclusion of unwanted files or directories,
      setuptools will not proceed with this build.
      
      If you are trying to create a single distribution with multiple packages
      on purpose, you should not rely on automatic discovery.
      Instead, consider the following options:
      
      1. set up custom discovery (`find` directive with `include` or `exclude`)
      2. use a `src-layout`
      3. explicitly set `py_modules` or `packages` with a list of names
      
      To find more information, look for "package discovery" on setuptools docs.
      [end of output]
  
  note: This error originates from a subprocess, and is likely not a problem with pip.
error: subprocess-exited-with-error

× Getting requirements to build editable did not run successfully.
│ exit code: 1
╰─> See above for output.

note: This error originates from a subprocess, and is likely not a problem with pip.
``` 

TBH, I'm not clear on the purpose of the GitHub action, but this pull request fixes the error by specifying `chorus_waveform` as the package to be installed. This can be updated later if needed, but at least tests pass again for now.

