### PR TITLE
Fix: AtriumDB Format is giving an `unable to open database` file error when looping over files

### DIFF
--- a/waveform_benchmark/formats/atriumdb.py
+++ b/waveform_benchmark/formats/atriumdb.py
@@ -20,7 +20,7 @@ class AtriumDB(BaseFormat):
     def write_waveforms(self, path, waveforms):
         # Create a new local dataset using SQLite
         global sdk
-        if sdk is None:
+        if sdk is None or path != sdk.dataset_location:
             sdk = AtriumSDK.create_dataset(dataset_location=path)
             sdk = AtriumSDK(dataset_location=path, num_threads=1)
             sdk.block.block_size = 16384


### PR DESCRIPTION
If we're doing many tests in one process, atriumdb should check if the desired save path has changed and if so make a new dataset at the new location.