### PR TITLE
Zarr conversion to `int` warning

### DIFF
--- a/waveform_benchmark/formats/zarr.py
+++ b/waveform_benchmark/formats/zarr.py
@@ -22,7 +22,7 @@ class Zarr(BaseFormat):
                 start = chunk['start_sample']
                 end = chunk['end_sample']
                 # Replace NaN values in the chunk with sentinel value
-                cursamples = np.where(np.isnan(chunk['samples']), nanval, np.round(chunk['samples'] * chunk['gain']).astype(np.int16)) 
+                cursamples = np.where(np.isnan(chunk['samples']), nanval, np.round(chunk['samples'] * chunk['gain'])).astype(np.int16)
                 samples[start:end] = cursamples
 
             if self.fmt == 'Compressed':


### PR DESCRIPTION
As mentioned in: https://github.com/chorus-ai/chorus_waveform/issues/114 when trying to convert a `nan` to an `int` a `RuntimeWarning: invalid value encountered in cast` warning is given. 

This line is setting a default `int` value (-32768) for NaNs but was previously trying to do the conversion to an `int` prior to 
changing the NaNs to the default value: 

`np.where(np.isnan(chunk['samples']), nanval, np.round(chunk['samples'] * chunk['gain']).astype(np.int16))`

This PR updates the code to finish the conversion to the default value prior to converting to an `int` which avoids the warning message. 