### PR TITLE
Update identification of `BaseFormat` during `benchmark.yml` run

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -97,7 +97,7 @@ jobs:
 
             # Find and list all classes in the module
             echo "Running benchmarks for classes in $MODULE_PATH"
-            CLASSES=$(python3 -c "import sys; import inspect; from importlib import import_module; mod = import_module('$MODULE_PATH'); print(' '.join(cls for cls, obj in inspect.getmembers(mod, inspect.isclass) if obj.__module__ == mod.__name__ and not cls.startswith('Base')))")
+            CLASSES=$(python3 -c "import sys; import inspect; from importlib import import_module; mod = import_module('$MODULE_PATH'); print(' '.join(cls for cls, obj in inspect.getmembers(mod, inspect.isclass) if obj.__module__ == mod.__name__ and not BaseFormat in obj.__bases__))")
             IFS=' ' read -ra CLS <<< "$CLASSES"
 
             for cls in "${CLS[@]}"


### PR DESCRIPTION
When a new / updated format is pushed to the repo we run a test from `benchmark.yml`. This test intends to exclude the base formats from the test by searching for `Base` at the start of the class name. However, not all of the base formats start with `Base`. All of the base formats are subclasses of `BaseFormat` though. 

This PR searches for `BaseFormat` in the object bases instead of a class name starting with `Base`. 