### PR TITLE
Add the option to Multithread AtriumDB

### DIFF
--- a/waveform_benchmark/formats/atriumdb.py
+++ b/waveform_benchmark/formats/atriumdb.py
@@ -16,14 +16,16 @@ class AtriumDB(BaseFormat):
     """
     AtriumDB, a time-indexed medical waveform database.
     """
+    num_threads = 1
+    num_values_per_block = 16384
 
     def write_waveforms(self, path, waveforms):
         # Create a new local dataset using SQLite
         global sdk
         if sdk is None or path != sdk.dataset_location:
             sdk = AtriumSDK.create_dataset(dataset_location=path)
-            sdk = AtriumSDK(dataset_location=path, num_threads=1)
-            sdk.block.block_size = 16384
+            sdk = AtriumSDK(dataset_location=path, num_threads=self.num_threads)
+            sdk.block.block_size = self.num_values_per_block
 
         device_tag = "chorus"
         chorus_device_id = sdk.insert_device(device_tag=device_tag)
@@ -240,6 +242,14 @@ class NanAdaptedAtriumDB(AtriumDB):
             results[signal_name] = read_value_data
 
         return results
+
+
+class AtriumDBMultiThreading(AtriumDB):
+    num_threads = 40
+
+
+class NanAdaptedAtriumDBMultiThreading(NanAdaptedAtriumDB):
+    num_threads = 40
 
 
 def generate_non_nan_slices(start_time_s: float, freq_hz: float, data: np.ndarray):


### PR DESCRIPTION
One of AtriumDB's strengths is its ability to use multiple threads at once to encode and decode blocks of data in parallel.

In order to optimize CPU time (number of CPUs * time spent processing), it was most efficient to run AtriumDB in single threaded mode (avoiding extra CPU time sharing information between cores).

However with the addition of the "Wall Time" metric, I thought it worthwhile to add a new AtriumDB subclass that utilizes its parallelization feature which optimizes Wall Time at the expense of CPU time.

To highlight an example of this tradeoff, below are the times it took for AtriumDB to write an entire Mimic record to disk with and without multithreading on a 40 core Linux server:

```
SingleThreaded AtriumDB:
CPU time: 212.1006 sec
Wall Time: 215.1170 s

MultiThreaded AtriumDB (40 threads):
CPU time: 435.6397 sec
Wall Time: 27.0486 s
```

As you can see, CPU time suffers by a factor of 2, while Wall time improves by a factor of 8.

These benefits are most apparent for large reads/writes, and disappear completely when the size of the task drops below 1 AtriumDB Block (whose size can also now be more easily adjusted in the source code of this PR).